### PR TITLE
AMEC-2461: Remove unused query for unique asset files

### DIFF
--- a/src/main/java/org/ambraproject/rhino/rest/controller/AssetFileCrudController.java
+++ b/src/main/java/org/ambraproject/rhino/rest/controller/AssetFileCrudController.java
@@ -26,7 +26,6 @@ import org.ambraproject.models.Article;
 import org.ambraproject.models.ArticleAsset;
 import org.ambraproject.rhino.identity.ArticleIdentity;
 import org.ambraproject.rhino.identity.AssetFileIdentity;
-import org.ambraproject.rhino.identity.AssetIdentity;
 import org.ambraproject.rhino.rest.RestClientException;
 import org.ambraproject.rhino.rest.controller.abstr.DoiBasedCrudController;
 import org.ambraproject.rhino.service.ArticleCrudService;
@@ -131,22 +130,6 @@ public class AssetFileCrudController extends DoiBasedCrudController {
   public void read(HttpServletRequest request, HttpServletResponse response)
       throws IOException, FileStoreException {
     read(request, response, parse(request));
-  }
-
-  /**
-   * Given the identity of an asset with exactly one associated file, serve the file. Respond with an error if it does
-   * not have exactly one file.
-   */
-  @Transactional(readOnly = true)
-  @RequestMapping(value = ASSET_TEMPLATE, method = RequestMethod.GET, params = {"unique"})
-  public void readUnique(HttpServletRequest request, HttpServletResponse response)
-      throws IOException, FileStoreException {
-    AssetIdentity assetId = AssetIdentity.create(getIdentifier(request));
-    AssetFileIdentity assetFileId = assetCrudService.findOnlyFile(assetId);
-    if (assetFileId == null) {
-      throw new RestClientException("No asset found with ID: " + assetId.getIdentifier(), HttpStatus.NOT_FOUND);
-    }
-    read(request, response, assetFileId);
   }
 
   private void read(HttpServletRequest request, HttpServletResponse response, AssetFileIdentity id)

--- a/src/main/java/org/ambraproject/rhino/service/AssetCrudService.java
+++ b/src/main/java/org/ambraproject/rhino/service/AssetCrudService.java
@@ -103,14 +103,4 @@ public interface AssetCrudService extends DoiBasedCrudService {
    */
   public abstract void overwrite(InputStream fileContent, AssetFileIdentity id) throws IOException, FileStoreException;
 
-  /**
-   * Find the identity of the only file for an asset.
-   *
-   * @param assetId the identity of an asset
-   * @return the identity of the only file belonging to the asset, or {@code null} if the asset has no associated files
-   * or does not exist
-   * @throws org.ambraproject.rhino.rest.RestClientException if the asset has more than one file
-   */
-  public abstract AssetFileIdentity findOnlyFile(AssetIdentity assetId);
-
 }

--- a/src/main/java/org/ambraproject/rhino/service/impl/AssetCrudServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/AssetCrudServiceImpl.java
@@ -429,19 +429,4 @@ public class AssetCrudServiceImpl extends AmbraService implements AssetCrudServi
     return new ArticleVisibility(articleDoi, articleState, journalResult);
   }
 
-  @Override
-  public AssetFileIdentity findOnlyFile(AssetIdentity assetId) {
-    List<String> extensions = hibernateTemplate.find("select extension from ArticleAsset where doi = ?", assetId.getKey());
-    switch (extensions.size()) {
-      case 0:
-        return null;
-      case 1:
-        return AssetFileIdentity.create(assetId.getIdentifier(), extensions.get(0));
-      default:
-        String message = String.format("Expected one extension for asset ID \"%s\". Found: %s",
-            assetId.getIdentifier(), extensions);
-        throw new RestClientException(message, HttpStatus.BAD_REQUEST);
-    }
-  }
-
 }


### PR DESCRIPTION
This service allowed Wombat to serve an asset file, if it had only the
asset ID, without querying for asset metadata. But now it must query for
asset metadata anyway in order to validate article visibility. Therefore
the unused service call is removed.
