### PR TITLE
DPRO-545: Split bucket name config values for editorial and corpus

### DIFF
--- a/src/main/java/org/ambraproject/rhino/config/RhinoConfiguration.java
+++ b/src/main/java/org/ambraproject/rhino/config/RhinoConfiguration.java
@@ -190,7 +190,7 @@ public class RhinoConfiguration extends BaseConfiguration {
   public ContentRepoServiceImpl contentRepoService(RuntimeConfiguration runtimeConfiguration) {
     ContentRepoAccessConfig accessConfig = BasicContentRepoAccessConfig.builder()
         .setRepoServer(runtimeConfiguration.getContentRepoAddress().toString())
-        .setBucketName(runtimeConfiguration.getRepoBucketName())
+        .setBucketName(runtimeConfiguration.getCorpusBucketName())
         .build();
     return new ContentRepoServiceFactory().createContentRepoService(accessConfig);
   }

--- a/src/main/java/org/ambraproject/rhino/config/RuntimeConfiguration.java
+++ b/src/main/java/org/ambraproject/rhino/config/RuntimeConfiguration.java
@@ -42,11 +42,19 @@ public interface RuntimeConfiguration {
   URI getContentRepoAddress();
 
   /**
-   * Return the name of the active bucket for the content repository.
+   * Return the name of the content repository bucket for the corpus of articles. The application will write to this
+   * bucket when ingesting articles and read from it when serving article assets.
    *
-   * @return the content repository bucket name
+   * @return the corpus bucket name
    */
-  String getRepoBucketName();
+  String getCorpusBucketName();
 
+  /**
+   * Return the name of the content repository bucket from which the system should pick up editorial (non-article)
+   * content.
+   *
+   * @return the homepage bucket name
+   */
+  String getEditorialBucketName();
 
 }

--- a/src/main/java/org/ambraproject/rhino/config/YamlConfiguration.java
+++ b/src/main/java/org/ambraproject/rhino/config/YamlConfiguration.java
@@ -47,17 +47,32 @@ public class YamlConfiguration implements RuntimeConfiguration {
 
     private boolean prettyPrintJson = true; // the default value should be true
     private URI contentRepoAddress = null;
-    private String repoBucketName = null;
+    private ContentRepoBuckets contentRepoBuckets;
 
     public void setPrettyPrintJson(boolean prettyPrintJson) {
       this.prettyPrintJson = prettyPrintJson;
     }
 
-    public void setcontentRepoAddress(URI contentRepoAddress) {
+    public void setContentRepoAddress(URI contentRepoAddress) {
       this.contentRepoAddress = contentRepoAddress;
     }
 
-    public void setRepoBucketName(String repoBucketName) { this.repoBucketName = repoBucketName; }
+    public void setContentRepoBuckets(ContentRepoBuckets contentRepoBuckets) {
+      this.contentRepoBuckets = contentRepoBuckets;
+    }
+
+    public static class ContentRepoBuckets {
+      private String editorial; // upstairs
+      private String corpus;  // downstairs
+
+      public void setEditorial(String editorial) {
+        this.editorial = editorial;
+      }
+
+      public void setCorpus(String corpus) {
+        this.corpus = corpus;
+      }
+    }
   }
 
   /**
@@ -74,8 +89,12 @@ public class YamlConfiguration implements RuntimeConfiguration {
   }
 
   @Override
-  public String getRepoBucketName() {
-    return uf.repoBucketName;
+  public String getCorpusBucketName() {
+    return (uf.contentRepoBuckets == null) ? null : uf.contentRepoBuckets.corpus;
   }
 
+  @Override
+  public String getEditorialBucketName() {
+    return (uf.contentRepoBuckets == null) ? null : uf.contentRepoBuckets.editorial;
+  }
 }

--- a/src/main/java/org/ambraproject/rhino/rest/controller/ContentRepoController.java
+++ b/src/main/java/org/ambraproject/rhino/rest/controller/ContentRepoController.java
@@ -1,7 +1,6 @@
 package org.ambraproject.rhino.rest.controller;
 
 import org.ambraproject.rhino.config.RuntimeConfiguration;
-import org.ambraproject.rhino.rest.RestClientException;
 import org.ambraproject.rhino.rest.controller.abstr.RestController;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,9 +35,9 @@ public class ContentRepoController extends RestController {
       return serveInDevMode(contentRepoAddress, key, version);
     }
 
-    String repoBucketName = runtimeConfiguration.getRepoBucketName();
+    String repoBucketName = runtimeConfiguration.getEditorialBucketName();
     if (repoBucketName == null) {
-      throw new RuntimeException("repoBucketName is not configured");
+      throw new RuntimeException("contentRepoBuckets.homepage is not configured");
     }
 
     return serveFromRemoteRepo(contentRepoAddress, repoBucketName, key, version);

--- a/src/main/java/org/ambraproject/rhino/service/impl/ConfigurationReadServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/ConfigurationReadServiceImpl.java
@@ -1,6 +1,7 @@
 package org.ambraproject.rhino.service.impl;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.ambraproject.rhino.config.RuntimeConfiguration;
 import org.ambraproject.rhino.service.ConfigurationReadService;
@@ -13,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Calendar;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Properties;
@@ -63,9 +65,14 @@ public class ConfigurationReadServiceImpl extends AmbraService implements Config
     return new Transceiver() {
       @Override
       protected Object getData() throws IOException {
-        Map<String, Object> cfgMap = new HashMap<>();
+        Map<String, Object> cfgMap = new LinkedHashMap<>();
         cfgMap.put("contentRepoAddress",runtimeConfiguration.getContentRepoAddress());
-        cfgMap.put("repoBucketName",runtimeConfiguration.getRepoBucketName());
+
+        Map<String, Object> bucketMap = new LinkedHashMap<>();
+        bucketMap.put("editorial", runtimeConfiguration.getEditorialBucketName());
+        bucketMap.put("corpus", runtimeConfiguration.getCorpusBucketName());
+        cfgMap.put("contentRepoBuckets", bucketMap);
+
         return cfgMap;
       }
 

--- a/src/test/resources/rhino-test.yaml
+++ b/src/test/resources/rhino-test.yaml
@@ -1,3 +1,4 @@
 prettyPrintJson: true
 contentRepoAddress: http://path/to/content/repo
-repoBucketName: bucket_name
+contentRepoBuckets:
+  editorial: bucket_name


### PR DESCRIPTION
Changes the expected input from rhino.yaml.
