### PR TITLE
DPRO-545: Allow editorial and corpus buckets to have separate crepo addresses

### DIFF
--- a/src/main/java/org/ambraproject/rhino/config/RhinoConfiguration.java
+++ b/src/main/java/org/ambraproject/rhino/config/RhinoConfiguration.java
@@ -200,6 +200,8 @@ public class RhinoConfiguration extends BaseConfiguration {
 
   @Bean
   public ContentRepoService contentRepoService(RuntimeConfiguration runtimeConfiguration) {
+    RuntimeConfiguration.ContentRepoEndpoint corpus = runtimeConfiguration.getCorpusBucket();
+
     /*
      * This BasicContentRepoAccessConfig object will have its own HttpClientConnectionManager object behind it. This is
      * redundant to the org.apache.commons.httpclient.HttpConnectionManager behind the httpClient bean, which (as
@@ -209,8 +211,8 @@ public class RhinoConfiguration extends BaseConfiguration {
      * connection manager for its 'open' method.
      */
     ContentRepoAccessConfig accessConfig = BasicContentRepoAccessConfig.builder()
-        .setRepoServer(runtimeConfiguration.getContentRepoAddress().toString())
-        .setBucketName(runtimeConfiguration.getCorpusBucketName())
+        .setRepoServer(corpus.getAddress().toString())
+        .setBucketName(corpus.getBucket())
         .build();
 
     return new ContentRepoServiceFactory().createContentRepoService(accessConfig);

--- a/src/main/java/org/ambraproject/rhino/config/RuntimeConfiguration.java
+++ b/src/main/java/org/ambraproject/rhino/config/RuntimeConfiguration.java
@@ -34,27 +34,35 @@ public interface RuntimeConfiguration {
   boolean prettyPrintJson();
 
   /**
-   * Return a URI at which to connect to a content repository API. If the URI has the {@code file} scheme (e.g., {@code
-   * file:///home/me/myDummyRepo/}), will simulate a "dev mode" content repository using files in that directory.
-   *
-   * @return the content repository URI
+   * Identifies a content repo bucket on a particular server.
    */
-  URI getContentRepoAddress();
+  interface ContentRepoEndpoint {
+    /**
+     * @return the URI of the server
+     */
+    URI getAddress();
+
+    /**
+     * @return the name of the bucket on that server to use
+     */
+    String getBucket();
+  }
 
   /**
-   * Return the name of the content repository bucket for the corpus of articles. The application will write to this
-   * bucket when ingesting articles and read from it when serving article assets.
+   * Return the content repository bucket for the corpus of articles. The application will write to this bucket when
+   * ingesting articles and read from it when serving article assets. Returns {@code null} if no corpus bucket is
+   * configured.
    *
    * @return the corpus bucket name
    */
-  String getCorpusBucketName();
+  ContentRepoEndpoint getCorpusBucket();
 
   /**
-   * Return the name of the content repository bucket from which the system should pick up editorial (non-article)
-   * content.
+   * Return the content repository bucket from which the system should pick up editorial (non-article) content. Returns
+   * {@code null} if no editorial bucket is configured.
    *
    * @return the homepage bucket name
    */
-  String getEditorialBucketName();
+  ContentRepoEndpoint getEditorialBucket();
 
 }

--- a/src/main/java/org/ambraproject/rhino/rest/controller/ContentRepoController.java
+++ b/src/main/java/org/ambraproject/rhino/rest/controller/ContentRepoController.java
@@ -27,20 +27,19 @@ public class ContentRepoController extends RestController {
   public ResponseEntity<?> serve(@PathVariable("key") String key,
                                  @PathVariable("version") String version)
       throws IOException {
-    URI contentRepoAddress = runtimeConfiguration.getContentRepoAddress();
-    if (contentRepoAddress == null) {
-      throw new RuntimeException("contentRepoAddress is not configured");
+    RuntimeConfiguration.ContentRepoEndpoint editorialBucket = runtimeConfiguration.getEditorialBucket();
+    URI address;
+    String bucketName;
+    if (editorialBucket == null
+        || (address = editorialBucket.getAddress()) == null
+        || (bucketName = editorialBucket.getBucket()) == null) {
+      throw new RuntimeException("contentRepo.editorial is not configured");
     }
-    if ("file".equals(contentRepoAddress.getScheme())) {
-      return serveInDevMode(contentRepoAddress, key, version);
+    if ("file".equals(address.getScheme())) {
+      return serveInDevMode(address, key, version);
     }
 
-    String repoBucketName = runtimeConfiguration.getEditorialBucketName();
-    if (repoBucketName == null) {
-      throw new RuntimeException("contentRepoBuckets.homepage is not configured");
-    }
-
-    return serveFromRemoteRepo(contentRepoAddress, repoBucketName, key, version);
+    return serveFromRemoteRepo(address, bucketName, key, version);
 
 
   }

--- a/src/main/java/org/ambraproject/rhino/service/impl/ConfigurationReadServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/ConfigurationReadServiceImpl.java
@@ -1,7 +1,6 @@
 package org.ambraproject.rhino.service.impl;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.ambraproject.rhino.config.RuntimeConfiguration;
 import org.ambraproject.rhino.service.ConfigurationReadService;
@@ -16,7 +15,6 @@ import java.util.Calendar;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Properties;
 
 public class ConfigurationReadServiceImpl extends AmbraService implements ConfigurationReadService {
@@ -60,19 +58,22 @@ public class ConfigurationReadServiceImpl extends AmbraService implements Config
     };
   }
 
+  private static Map<String, Object> showEndpointAsMap(RuntimeConfiguration.ContentRepoEndpoint endpoint) {
+    if (endpoint == null) return null;
+    Map<String, Object> map = new LinkedHashMap<>(4);
+    map.put("address", endpoint.getAddress());
+    map.put("bucket", endpoint.getBucket());
+    return map;
+  }
+
   @Override
   public Transceiver readRepoConfig() throws IOException {
     return new Transceiver() {
       @Override
       protected Object getData() throws IOException {
-        Map<String, Object> cfgMap = new LinkedHashMap<>();
-        cfgMap.put("contentRepoAddress",runtimeConfiguration.getContentRepoAddress());
-
-        Map<String, Object> bucketMap = new LinkedHashMap<>();
-        bucketMap.put("editorial", runtimeConfiguration.getEditorialBucketName());
-        bucketMap.put("corpus", runtimeConfiguration.getCorpusBucketName());
-        cfgMap.put("contentRepoBuckets", bucketMap);
-
+        Map<String, Object> cfgMap = new LinkedHashMap<>(4);
+        cfgMap.put("editorial", showEndpointAsMap(runtimeConfiguration.getEditorialBucket()));
+        cfgMap.put("corpus", showEndpointAsMap(runtimeConfiguration.getCorpusBucket()));
         return cfgMap;
       }
 

--- a/src/test/java/org/ambraproject/rhino/service/ConfigurationReadServiceTest.java
+++ b/src/test/java/org/ambraproject/rhino/service/ConfigurationReadServiceTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -55,12 +54,12 @@ public class ConfigurationReadServiceTest extends BaseRhinoTest {
     String repoConfigJson = configurationReadService.readRepoConfig().readJson(entityGson);
     assertTrue(repoConfigJson.length() > 0, "ConfigurationReadService did not return content repo configuration");
     Map<String, Object> repoConfigMap = entityGson.fromJson(repoConfigJson, HashMap.class);
-    String repoAddress = repoConfigMap.get("contentRepoAddress").toString();
-    assertEquals(repoAddress, "http://path/to/content/repo", "Invalid/missing content repo URL");
+    Map<String, Object> editorialConfigMap = (Map<String, Object>) repoConfigMap.get("editorial");
 
-    Map<String, Object> repoBucketMap = (Map<String, Object>) repoConfigMap.get("contentRepoBuckets");
-    assertNotNull(repoBucketMap);
-    assertEquals(repoBucketMap.get("editorial"), "bucket_name", "Invalid/missing content repo bucket name");
+    String repoAddress = editorialConfigMap.get("address").toString();
+    assertEquals(repoAddress, "http://path/to/content/repo", "Invalid/missing content repo URL");
+    String repoBucket = editorialConfigMap.get("bucket").toString();
+    assertEquals(repoBucket, "bucket_name", "Invalid/missing content repo bucket name");
   }
 
 }

--- a/src/test/resources/rhino-test.yaml
+++ b/src/test/resources/rhino-test.yaml
@@ -1,4 +1,8 @@
 prettyPrintJson: true
-contentRepoAddress: http://path/to/content/repo
-contentRepoBuckets:
-  editorial: bucket_name
+contentRepo:
+  editorial:
+    address: http://path/to/content/repo
+    bucket:  bucket_name
+  corpus:
+    address: http://path/to/content/repo
+    bucket:  bucket_name


### PR DESCRIPTION
Now that we're allowing Rhino's config to specify two content repo buckets, it seems silly to require them to be on the same content repo server. So far, this constraint exists only in the actual config code, which this patch seeks to rectify.

This would be a further to revision to the config spec (continuing on changes earlier in dev-DPRO-545; they haven't gone to master yet). As follows...

Before:

``` yaml
prettyPrintJson: true
contentRepoAddress: "http://example.org:8002/v1/"
contentRepoBuckets:
  editorial: plive
  corpus:    corpus
```

After:

``` yaml
prettyPrintJson: true
contentRepo:
  editorial:
    address: "http://example.org:8002/v1/"
    bucket:  plive
  corpus:
    address: "http://example.org:8002/v1/"
    bucket:  corpus
```
