### PR TITLE
dev-DPRO-1075: Change crepo-lib dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <dependency>
       <groupId>org.plos</groupId>
       <artifactId>content-repo-library</artifactId>
-      <version>1.5.0-SNAPSHOT</version>
+      <version>1.5.0</version>
     </dependency>
 
     <!-- ========================= End Ambra inclusions ========================= -->


### PR DESCRIPTION
Change crepo-lib version from 1.5.0-SNAPSHOT to 1.5.0
