### PR TITLE
DPRO-1210: add back some required dependencies related to ehcache.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <conf-helper.version>2.2.1</conf-helper.version>
     <camel.version>2.10.4</camel.version>
     <activemq.version>5.2.0</activemq.version>
+    <ehcache.version>2.7.0</ehcache.version>
   </properties>
 
   <repositories>
@@ -272,6 +273,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-context-support</artifactId>
+      <version>${org.springframework-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <version>${org.springframework-version}</version>
     </dependency>
@@ -378,6 +384,12 @@
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-camel</artifactId>
       <version>${activemq.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>net.sf.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>${ehcache.version}</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
Previously, these were being pulled in as transitive dependencies from
some ambra components.  However, after upgrading to spring 4.1, I added
exclude rules that prevented spring from being pulled in from ambra,
since it was the old version (pre-4).

To make things worse, this bug only shows up when you deploy the
rhino.war to an external tomcat container; everything works fine when
you either run from IntelliJ or from maven.
