### PR TITLE
DPRO-1310: Avoid needlessly reading multipart from from request to disk

### DIFF
--- a/src/main/java/org/ambraproject/rhino/rest/controller/IngestibleZipController.java
+++ b/src/main/java/org/ambraproject/rhino/rest/controller/IngestibleZipController.java
@@ -18,7 +18,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -50,8 +49,6 @@ public class IngestibleZipController extends RestController {
       throws IOException {
 
     String archiveName = requestFile.getOriginalFilename();
-    String zipFilename = System.getProperty("java.io.tmpdir") + File.separator + archiveName;
-    requestFile.transferTo(new File(zipFilename));
     Article result;
     try (InputStream requestInputStream = requestFile.getInputStream();
          Archive archive = Archive.readZipFile(archiveName, requestInputStream)) {


### PR DESCRIPTION
The removed lines were not needed and might have caused an
environment-dependent error by exhausting the request stream.
