### PR TITLE
DPRO-1384: Validate that DOI given by manuscript matches manifest

### DIFF
--- a/src/main/java/org/ambraproject/rhino/service/impl/VersionedIngestionService.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/VersionedIngestionService.java
@@ -143,6 +143,11 @@ class VersionedIngestionService {
       parsedArticle = new ArticleXml(AmbraService.parseXml(manuscriptStream));
     }
     ArticleIdentity articleIdentity = parsedArticle.readDoi();
+    if (!manuscriptAsset.getUri().equals(articleIdentity.getKey())) {
+      String message = String.format("Article DOI is inconsistent. From manifest: \"%s\" From manuscript: \"%s\"",
+          manuscriptAsset.getUri(), articleIdentity.getKey());
+      throw new RestClientException(message, HttpStatus.BAD_REQUEST);
+    }
     final Article articleMetadata = parsedArticle.build(new Article());
 
     AssetTable<String> assetTable = AssetTable.buildFromIngestible(parsedArticle.findAllAssetNodes(), manifestXml);


### PR DESCRIPTION
Prevents a cryptic failure in which the ingestion service attempts to
represent the manuscript with two objects, which have different keys but
the same archiveEntryName. Now throws a deliberate error instead.
