### PR TITLE
DPRO-1382: fix manifest recreation during repack - do not include

### DIFF
--- a/src/main/java/org/ambraproject/rhino/service/impl/LegacyIngestionService.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/LegacyIngestionService.java
@@ -860,16 +860,15 @@ class LegacyIngestionService {
 
   /**
    * Iterate through an article's assets to determine if the article has a PDF representation
+   * The PDF asset DOI is equal to the article DOI, and the extension is "PDF".
    *
    * @param article the article to analyze
    * @return boolean indicating existence of article PDF representation
    */
   private static boolean articleHasPdfRepresentation(Article article) {
-    String articleNameStub = inferFileName(ArticleIdentity.create(article));
     for (ArticleAsset articleAsset : article.getAssets()) {
-      final AssetFileIdentity assetFileIdentity = AssetFileIdentity.from(articleAsset);
-      String entryName = inferFileName(assetFileIdentity) + "." + assetFileIdentity.getFileExtension();
-      if (entryName.equals(articleNameStub + ".PDF")) {
+      if (articleAsset.getDoi().equals(article.getDoi())
+          && articleAsset.getExtension().equals("PDF")) {
         return true;
       }
     }


### PR DESCRIPTION
article PDF representation entry if no article PDF asset exists

Assigning @rskonnord-plos 

I feel like there should be a better way of determining if the article has a PDF representation
