### PR TITLE
DPRO-1404: Modify POST and PATCH API for collection to use JSON body

### DIFF
--- a/src/main/java/org/ambraproject/rhino/config/json/AdapterRegistry.java
+++ b/src/main/java/org/ambraproject/rhino/config/json/AdapterRegistry.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import org.ambraproject.rhino.view.JsonOutputView;
 import org.ambraproject.rhino.view.KeyedStringList;
 import org.ambraproject.rhino.view.article.ArticleInputView;
+import org.ambraproject.rhino.view.article.CollectionInputView;
 import org.ambraproject.rhino.view.article.DoiList;
 import org.ambraproject.rhino.view.user.AuthIdList;
 
@@ -85,6 +86,7 @@ public class AdapterRegistry {
       .put(DoiList.class, KeyedStringList.ADAPTER)
       .put(AuthIdList.class, KeyedStringList.ADAPTER)
       .put(ArticleInputView.class, ArticleInputView.DESERIALIZER)
+      .put(CollectionInputView.class, CollectionInputView.DESERIALIZER)
       .build();
 
 

--- a/src/main/java/org/ambraproject/rhino/identity/ArticleIdentity.java
+++ b/src/main/java/org/ambraproject/rhino/identity/ArticleIdentity.java
@@ -20,7 +20,7 @@ package org.ambraproject.rhino.identity;
 
 import org.ambraproject.models.Article;
 
-public class ArticleIdentity extends DoiBasedIdentity {
+public final class ArticleIdentity extends DoiBasedIdentity {
 
   private ArticleIdentity(String identifier) {
     super(identifier);

--- a/src/main/java/org/ambraproject/rhino/service/CollectionCrudService.java
+++ b/src/main/java/org/ambraproject/rhino/service/CollectionCrudService.java
@@ -1,5 +1,6 @@
 package org.ambraproject.rhino.service;
 
+import com.google.common.base.Optional;
 import org.ambraproject.rhino.identity.ArticleIdentity;
 import org.ambraproject.rhino.model.ArticleCollection;
 import org.ambraproject.rhino.util.response.Transceiver;
@@ -24,17 +25,18 @@ public interface CollectionCrudService {
    * Modify an existing collection.
    * <p/>
    * The first two arguments identify the collection to modify. The last two arguments represent new values to assign,
-   * and a {@code null} value signifies that the value should not be modified. Note that a non-null value of {@code
+   * and an absent value signifies that the value should not be modified. Note that a present value of {@code
    * articleIds} completely replaces the old collection of articles; omitting an article that is already in the
    * collection will remove it.
    *
    * @param journalKey the key of the journal to which the collection belongs
    * @param slug       the slug of the collection to modify
-   * @param title      the new collection title, or {@code null} to leave the title unchanged
-   * @param articleIds the new set of articles in the collection, or {@code null} to leave them unchanged
+   * @param title      the new collection title (leave the title unchanged if absent)
+   * @param articleIds the new set of articles in the collection (leave them unchanged if absent)
    * @return the modified collection
    */
-  ArticleCollection update(String journalKey, String slug, String title, Set<ArticleIdentity> articleIds);
+  ArticleCollection update(String journalKey, String slug,
+                           Optional<String> title, Optional<? extends Set<ArticleIdentity>> articleIds);
 
   Transceiver read(String journalKey, String slug);
 

--- a/src/main/java/org/ambraproject/rhino/service/impl/CollectionCrudServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/CollectionCrudServiceImpl.java
@@ -1,5 +1,6 @@
 package org.ambraproject.rhino.service.impl;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -70,19 +71,18 @@ public class CollectionCrudServiceImpl extends AmbraService implements Collectio
 
   @Override
   public ArticleCollection update(final String journalKey, final String slug,
-                                  String title, Set<ArticleIdentity> articleIds) {
+                                  Optional<String> title, Optional<? extends Set<ArticleIdentity>> articleIds) {
     ArticleCollection coll = getCollection(journalKey, slug);
     if (coll == null) {
       throw new RestClientException("Collection does not exist", HttpStatus.NOT_FOUND);
     }
 
-    if (title != null) {
-      coll.setTitle(title);
+    if (title.isPresent()) {
+      coll.setTitle(title.get());
     }
 
-    if (articleIds != null) {
-      Preconditions.checkArgument(!articleIds.isEmpty());
-      List<Article> newArticles = fetchArticles(articleIds);
+    if (articleIds.isPresent()) {
+      List<Article> newArticles = fetchArticles(articleIds.get());
       List<Article> oldArticles = coll.getArticles();
       oldArticles.clear();
       oldArticles.addAll(newArticles);

--- a/src/main/java/org/ambraproject/rhino/view/article/CollectionInputView.java
+++ b/src/main/java/org/ambraproject/rhino/view/article/CollectionInputView.java
@@ -1,0 +1,81 @@
+package org.ambraproject.rhino.view.article;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import org.ambraproject.rhino.identity.ArticleIdentity;
+
+import java.lang.reflect.Type;
+import java.util.Set;
+
+public class CollectionInputView {
+
+  private final Optional<String> title;
+  private final Optional<ImmutableSet<ArticleIdentity>> articleIds;
+
+  private CollectionInputView(String title, Set<ArticleIdentity> articleIds) {
+    this.title = Optional.fromNullable(title);
+    this.articleIds = (articleIds == null) ? Optional.<ImmutableSet<ArticleIdentity>>absent()
+        : Optional.of(ImmutableSet.copyOf(articleIds));
+  }
+
+  public Optional<String> getTitle() {
+    return title;
+  }
+
+  public Optional<ImmutableSet<ArticleIdentity>> getArticleIds() {
+    return articleIds;
+  }
+
+  public static final JsonDeserializer<CollectionInputView> DESERIALIZER = new JsonDeserializer<CollectionInputView>() {
+    @Override
+    public CollectionInputView deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+      JsonObject jsonObject = json.getAsJsonObject();
+
+      JsonElement titleElement = jsonObject.get("title");
+      String title = (titleElement == null || titleElement.isJsonNull()) ? null : titleElement.getAsString();
+
+      JsonElement articleDoisElement = jsonObject.get("articleDois");
+      Set<ArticleIdentity> articleIds;
+      if (articleDoisElement == null || articleDoisElement.isJsonNull()) {
+        articleIds = null;
+      } else {
+        JsonArray articleDoisArray = articleDoisElement.getAsJsonArray();
+        articleIds = Sets.newLinkedHashSetWithExpectedSize(articleDoisArray.size());
+        for (JsonElement articleDoiElement : articleDoisArray) {
+          String articleDoi = articleDoiElement.getAsString();
+          articleIds.add(ArticleIdentity.create(articleDoi));
+        }
+      }
+
+      return new CollectionInputView(title, articleIds);
+    }
+  };
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    CollectionInputView that = (CollectionInputView) o;
+
+    if (!articleIds.equals(that.articleIds)) return false;
+    if (!title.equals(that.title)) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = title.hashCode();
+    result = 31 * result + articleIds.hashCode();
+    return result;
+  }
+}


### PR DESCRIPTION
This allows arbitrarily long lists of articles, preventing problem with
lengthy query strings or headers. It also solves the problem of
distinguishing an empty list from "no update" in PATCH.
