### PR TITLE
DPRO-1679: Present volume and issue views as lists instead of maps

### DIFF
--- a/src/main/java/org/ambraproject/rhino/config/json/AdapterRegistry.java
+++ b/src/main/java/org/ambraproject/rhino/config/json/AdapterRegistry.java
@@ -62,14 +62,12 @@ public class AdapterRegistry {
 
       .add(org.ambraproject.rhino.view.journal.ArticleListView.class)
       .add(org.ambraproject.rhino.view.journal.IssueOutputView.class)
-      .add(org.ambraproject.rhino.view.journal.IssueOutputView.ListView.class)
       .add(org.ambraproject.rhino.view.journal.JournalListView.class)
       .add(org.ambraproject.rhino.view.journal.JournalNonAssocView.class)
       .add(org.ambraproject.rhino.view.journal.JournalNonAssocView.ListView.class)
       .add(org.ambraproject.rhino.view.journal.JournalOutputView.class)
       .add(org.ambraproject.rhino.view.journal.VolumeListView.class)
       .add(org.ambraproject.rhino.view.journal.VolumeOutputView.class)
-      .add(org.ambraproject.rhino.view.journal.VolumeOutputView.ListView.class)
 
       .add(org.ambraproject.rhino.view.AnnotationOutputView.class)
 

--- a/src/main/java/org/ambraproject/rhino/view/journal/IssueOutputView.java
+++ b/src/main/java/org/ambraproject/rhino/view/journal/IssueOutputView.java
@@ -6,12 +6,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import org.ambraproject.models.Issue;
-import org.ambraproject.models.Volume;
 import org.ambraproject.rhino.identity.DoiBasedIdentity;
 import org.ambraproject.rhino.view.JsonOutputView;
-import org.ambraproject.rhino.view.KeyedListView;
 
-import java.util.Collection;
 import java.util.List;
 
 public class IssueOutputView implements JsonOutputView {
@@ -42,26 +39,6 @@ public class IssueOutputView implements JsonOutputView {
     }
 
     return serialized;
-  }
-
-  public static class ListView extends KeyedListView<Issue> {
-    private ListView(Collection<? extends Issue> values) {
-      super(values);
-    }
-
-    @Override
-    protected String getKey(Issue value) {
-      return DoiBasedIdentity.asIdentifier(value.getIssueUri());
-    }
-
-    @Override
-    protected Object wrap(Issue value) {
-      return new IssueOutputView(value);
-    }
-  }
-
-  public static KeyedListView<Issue> wrapList(Collection<Issue> issues) {
-    return new ListView(issues);
   }
 
 }

--- a/src/main/java/org/ambraproject/rhino/view/journal/JournalOutputView.java
+++ b/src/main/java/org/ambraproject/rhino/view/journal/JournalOutputView.java
@@ -1,6 +1,7 @@
 package org.ambraproject.rhino.view.journal;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
@@ -8,7 +9,6 @@ import org.ambraproject.models.Issue;
 import org.ambraproject.models.Journal;
 import org.ambraproject.models.Volume;
 import org.ambraproject.rhino.view.JsonOutputView;
-import org.ambraproject.rhino.view.KeyedListView;
 
 import java.util.List;
 
@@ -29,8 +29,8 @@ public class JournalOutputView implements JsonOutputView {
     JsonObject serialized = context.serialize(journal).getAsJsonObject();
 
     List<Volume> volumes = journal.getVolumes();
-    KeyedListView<Volume> volumeView = VolumeOutputView.wrapList(volumes);
-    serialized.add("volumes", context.serialize(volumeView));
+    List<VolumeOutputView> volumeViews = Lists.transform(volumes, VolumeOutputView::new);
+    serialized.add("volumes", context.serialize(volumeViews));
 
     Issue currentIssue = journal.getCurrentIssue();
     if (currentIssue != null) {

--- a/src/main/java/org/ambraproject/rhino/view/journal/VolumeOutputView.java
+++ b/src/main/java/org/ambraproject/rhino/view/journal/VolumeOutputView.java
@@ -1,16 +1,14 @@
 package org.ambraproject.rhino.view.journal;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
-import org.ambraproject.models.Issue;
 import org.ambraproject.models.Volume;
-import org.ambraproject.rhino.identity.DoiBasedIdentity;
 import org.ambraproject.rhino.view.JsonOutputView;
-import org.ambraproject.rhino.view.KeyedListView;
 
-import java.util.Collection;
+import java.util.List;
 
 public class VolumeOutputView implements JsonOutputView {
 
@@ -23,29 +21,9 @@ public class VolumeOutputView implements JsonOutputView {
   @Override
   public JsonElement serialize(JsonSerializationContext context) {
     JsonObject serialized = context.serialize(volume).getAsJsonObject();
-    KeyedListView<Issue> issueView = IssueOutputView.wrapList(volume.getIssues());
-    serialized.add("issues", context.serialize(issueView));
+    List<IssueOutputView> issueViews = Lists.transform(volume.getIssues(), IssueOutputView::new);
+    serialized.add("issues", context.serialize(issueViews));
     return serialized;
-  }
-
-  public static class ListView extends KeyedListView<Volume> {
-    private ListView(Collection<? extends Volume> values) {
-      super(values);
-    }
-
-    @Override
-    protected String getKey(Volume value) {
-      return DoiBasedIdentity.asIdentifier(value.getVolumeUri());
-    }
-
-    @Override
-    protected Object wrap(Volume value) {
-      return new VolumeOutputView(value);
-    }
-  }
-
-  public static KeyedListView<Volume> wrapList(Collection<Volume> volumes) {
-    return new ListView(volumes);
   }
 
 }


### PR DESCRIPTION
The former API was obscuring the order of the issue list within each volume
and the volume list within each journal. The order is a persisted value and
we need to provide it one way or another.

This breaks backwards compatibility in principle, but there should be no
Wombat code that depends on this.
