### PR TITLE
DPRO-2239: Provide comment count in regular article metadata

### DIFF
--- a/src/main/java/org/ambraproject/rhino/service/AnnotationCrudService.java
+++ b/src/main/java/org/ambraproject/rhino/service/AnnotationCrudService.java
@@ -19,6 +19,7 @@ import org.ambraproject.models.Flag;
 import org.ambraproject.rhino.identity.ArticleIdentity;
 import org.ambraproject.rhino.identity.DoiBasedIdentity;
 import org.ambraproject.rhino.util.response.Transceiver;
+import org.ambraproject.rhino.view.comment.CommentCount;
 import org.ambraproject.rhino.view.comment.CommentFlagInputView;
 import org.ambraproject.rhino.view.comment.CommentInputView;
 
@@ -56,6 +57,6 @@ public interface AnnotationCrudService {
 
   public Transceiver readRecentComments(String journalKey, OptionalInt limit);
 
-  public long getCommentCount(Article article);
+  public CommentCount getCommentCount(Article article);
 
 }

--- a/src/main/java/org/ambraproject/rhino/service/impl/AnnotationCrudServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/AnnotationCrudServiceImpl.java
@@ -29,6 +29,7 @@ import org.ambraproject.rhino.service.AnnotationCrudService;
 import org.ambraproject.rhino.util.response.Transceiver;
 import org.ambraproject.rhino.view.comment.AnnotationNodeView;
 import org.ambraproject.rhino.view.comment.AnnotationOutputView;
+import org.ambraproject.rhino.view.comment.CommentCount;
 import org.ambraproject.rhino.view.comment.CommentFlagInputView;
 import org.ambraproject.rhino.view.comment.CommentInputView;
 import org.hibernate.FetchMode;
@@ -261,9 +262,12 @@ public class AnnotationCrudServiceImpl extends AmbraService implements Annotatio
   }
 
   @Override
-  public long getCommentCount(Article article) {
-    return (Long) DataAccessUtils.requiredSingleResult(hibernateTemplate.find(
+  public CommentCount getCommentCount(Article article) {
+    long root = (Long) DataAccessUtils.requiredSingleResult(hibernateTemplate.find(
+        "SELECT COUNT(*) FROM Annotation WHERE articleID = ? AND parentID IS NULL", article.getID()));
+    long all = (Long) DataAccessUtils.requiredSingleResult(hibernateTemplate.find(
         "SELECT COUNT(*) FROM Annotation WHERE articleID = ?", article.getID()));
+    return new CommentCount(root, all);
   }
 
 }

--- a/src/main/java/org/ambraproject/rhino/view/article/ArticleOutputView.java
+++ b/src/main/java/org/ambraproject/rhino/view/article/ArticleOutputView.java
@@ -40,6 +40,7 @@ import org.ambraproject.rhino.view.JsonOutputView;
 import org.ambraproject.rhino.view.KeyedListView;
 import org.ambraproject.rhino.view.asset.groomed.GroomedAssetsView;
 import org.ambraproject.rhino.view.asset.raw.RawAssetCollectionView;
+import org.ambraproject.rhino.view.comment.CommentCount;
 import org.ambraproject.rhino.view.journal.JournalNonAssocView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +86,7 @@ public class ArticleOutputView implements JsonOutputView, ArticleView {
     private final ImmutableList<ArticleIssue> articleIssues;
     private final ImmutableMap<String, Syndication> syndications;
     private final ImmutableList<Pingback> pingbacks;
-    private final long commentCount;
+    private final CommentCount commentCount;
 
     // Package-private; should be called only by ArticleOutputViewFactory
     AugmentedView(Article article,
@@ -95,7 +96,7 @@ public class ArticleOutputView implements JsonOutputView, ArticleView {
                   Collection<ArticleIssue> articleIssues,
                   Collection<Syndication> syndications,
                   Collection<Pingback> pingbacks,
-                  long commentCount,
+                  CommentCount commentCount,
                   boolean excludeCitations) {
       super(article, excludeCitations);
       this.nlmArticleType = Optional.fromNullable(nlmArticleType);
@@ -121,7 +122,7 @@ public class ArticleOutputView implements JsonOutputView, ArticleView {
         serialized.add("articleType", context.serialize(articleType.get()));
       }
 
-      serialized.addProperty("commentCount", commentCount);
+      serialized.add("commentCount", context.serialize(commentCount));
 
       JsonElement syndications = serializeSyndications(this.syndications.values(), context);
       if (syndications != null) {

--- a/src/main/java/org/ambraproject/rhino/view/article/ArticleOutputViewFactory.java
+++ b/src/main/java/org/ambraproject/rhino/view/article/ArticleOutputViewFactory.java
@@ -11,6 +11,7 @@ import org.ambraproject.rhino.service.ArticleType;
 import org.ambraproject.rhino.service.ArticleTypeService;
 import org.ambraproject.rhino.service.IssueCrudService;
 import org.ambraproject.rhino.service.PingbackReadService;
+import org.ambraproject.rhino.view.comment.CommentCount;
 import org.ambraproject.service.article.NoSuchArticleIdException;
 import org.ambraproject.service.syndication.SyndicationService;
 import org.slf4j.Logger;
@@ -66,7 +67,7 @@ public class ArticleOutputViewFactory {
 
     List<ArticleIssue> articleIssues = issueCrudService.getArticleIssues(articleIdentity);
 
-    long commentCount = annotationCrudService.getCommentCount(article);
+    CommentCount commentCount = annotationCrudService.getCommentCount(article);
 
     return new ArticleOutputView.AugmentedView(
         article,

--- a/src/main/java/org/ambraproject/rhino/view/comment/CommentCount.java
+++ b/src/main/java/org/ambraproject/rhino/view/comment/CommentCount.java
@@ -1,0 +1,11 @@
+package org.ambraproject.rhino.view.comment;
+
+public class CommentCount {
+  private final long root;
+  private final long all;
+
+  public CommentCount(long root, long all) {
+    this.root = root;
+    this.all = all;
+  }
+}


### PR DESCRIPTION
This extra datum obviates extra calls from the client to the more expensive
'readComments' endpoint.
