### PR TITLE
DPRO-2234: Improve exception handling

### DIFF
--- a/src/main/java/org/ambraproject/rhino/service/taxonomy/TaxonomyClassificationService.java
+++ b/src/main/java/org/ambraproject/rhino/service/taxonomy/TaxonomyClassificationService.java
@@ -5,7 +5,6 @@ import org.w3c.dom.Document;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Service for assigning taxonomic terms to an article.
@@ -20,9 +19,9 @@ public interface TaxonomyClassificationService {
    * @return a map of categories to which the article belongs. Each entry should use <code>/</code>s to delimit subject
    * hierarchy.  Categories are returned in descending order of the strength of the match paired with the strength
    * value
-   * @throws TaxonomyClassificationServiceNotConfiguredException if a remote service is required but not configured
+   * @throws TaxonomyRemoteServiceNotConfiguredException if a remote service is required but not configured
    */
-  public List<WeightedTerm> classifyArticle(Document articleXml, Article article) throws IOException;
+  public List<WeightedTerm> classifyArticle(Document articleXml, Article article);
 
   /**
    * Queries the MAI server for taxonomic terms for a given article, and returns a list of the raw results.
@@ -38,14 +37,5 @@ public interface TaxonomyClassificationService {
    */
   public List<String> getRawTerms(Document articleXml, Article article,
                                   boolean isTextRequired) throws IOException;
-
-  /**
-   * Indicates that a remote service is required to classify articles but is not configured on this system.
-   */
-  public static class TaxonomyClassificationServiceNotConfiguredException extends RuntimeException {
-    public TaxonomyClassificationServiceNotConfiguredException() {
-      super();
-    }
-  }
 
 }

--- a/src/main/java/org/ambraproject/rhino/service/taxonomy/TaxonomyRemoteServiceInvalidBehaviorException.java
+++ b/src/main/java/org/ambraproject/rhino/service/taxonomy/TaxonomyRemoteServiceInvalidBehaviorException.java
@@ -1,0 +1,14 @@
+package org.ambraproject.rhino.service.taxonomy;
+
+/**
+ * Indicates that the remote taxonomy service returned an unusable value.
+ */
+public class TaxonomyRemoteServiceInvalidBehaviorException extends RuntimeException {
+  public TaxonomyRemoteServiceInvalidBehaviorException(String message) {
+    super(message);
+  }
+
+  public TaxonomyRemoteServiceInvalidBehaviorException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/org/ambraproject/rhino/service/taxonomy/TaxonomyRemoteServiceNotAvailableException.java
+++ b/src/main/java/org/ambraproject/rhino/service/taxonomy/TaxonomyRemoteServiceNotAvailableException.java
@@ -1,0 +1,13 @@
+package org.ambraproject.rhino.service.taxonomy;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Indicates that a connection to the remote taxonomy service failed.
+ */
+public class TaxonomyRemoteServiceNotAvailableException extends RuntimeException {
+  public TaxonomyRemoteServiceNotAvailableException(IOException cause) {
+    super(Objects.requireNonNull(cause));
+  }
+}

--- a/src/main/java/org/ambraproject/rhino/service/taxonomy/TaxonomyRemoteServiceNotConfiguredException.java
+++ b/src/main/java/org/ambraproject/rhino/service/taxonomy/TaxonomyRemoteServiceNotConfiguredException.java
@@ -1,0 +1,10 @@
+package org.ambraproject.rhino.service.taxonomy;
+
+/**
+ * Indicates that a remote service is required to classify articles but is not configured on this system.
+ */
+public class TaxonomyRemoteServiceNotConfiguredException extends RuntimeException {
+  public TaxonomyRemoteServiceNotConfiguredException() {
+    super();
+  }
+}

--- a/src/main/java/org/ambraproject/rhino/service/taxonomy/impl/TaxonomyServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/taxonomy/impl/TaxonomyServiceImpl.java
@@ -22,7 +22,7 @@ public class TaxonomyServiceImpl extends AmbraService implements TaxonomyService
   private TaxonomyClassificationService taxonomyClassificationService;
 
   @Override
-  public List<WeightedTerm> classifyArticle(Document articleXml, Article article) throws IOException {
+  public List<WeightedTerm> classifyArticle(Document articleXml, Article article) {
     return taxonomyClassificationService.classifyArticle(articleXml, article);
   }
 

--- a/src/test/java/org/ambraproject/rhino/service/taxonomy/DummyTaxonomyClassificationService.java
+++ b/src/test/java/org/ambraproject/rhino/service/taxonomy/DummyTaxonomyClassificationService.java
@@ -1,7 +1,6 @@
 package org.ambraproject.rhino.service.taxonomy;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.ambraproject.models.Article;
 import org.w3c.dom.Document;
 
@@ -16,7 +15,7 @@ public class DummyTaxonomyClassificationService implements TaxonomyClassificatio
       .build();
 
   @Override
-  public List<WeightedTerm> classifyArticle(Document articleXml, Article article) throws IOException {
+  public List<WeightedTerm> classifyArticle(Document articleXml, Article article) {
     return DUMMY_DATA;
   }
 

--- a/src/test/java/org/ambraproject/rhino/service/taxonomy/impl/TaxonomyClassificationServiceImplTest.java
+++ b/src/test/java/org/ambraproject/rhino/service/taxonomy/impl/TaxonomyClassificationServiceImplTest.java
@@ -19,6 +19,7 @@
 package org.ambraproject.rhino.service.taxonomy.impl;
 
 import org.ambraproject.rhino.service.taxonomy.TaxonomyClassificationService;
+import org.ambraproject.rhino.service.taxonomy.TaxonomyRemoteServiceInvalidBehaviorException;
 import org.ambraproject.rhino.service.taxonomy.WeightedTerm;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.testng.annotations.Test;
@@ -31,7 +32,6 @@ import java.io.File;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -154,7 +154,7 @@ public class TaxonomyClassificationServiceImplTest {
             , 67));
   }
 
-  @Test(expectedExceptions = TaxonomyClassificationServiceImpl.InvalidTaxonomyElementException.class)
+  @Test(expectedExceptions = TaxonomyRemoteServiceInvalidBehaviorException.class)
   public void testInvalidVectorElement() throws Exception {
     // This appears to be a bug in the AI server--it sometimes does not return an
     // absolute path to a top-level category.  In these cases, the returned value


### PR DESCRIPTION
Reverted handling on individual terms with invalid syntax, so that we no
longer omit only that term and persist the rest.

Changed exception-swallowing in populateCategories so that errors cause the
"repopulateCategories" service to respond with a 500 status. But,
exceptions (even unanticipated RuntimeExceptions) from category population
will not halt an ingestion.

Rearranged custom exception types for clarity.
