### PR TITLE
DPRO-2588: Extract drop_user_tables.sql

### DIFF
--- a/src/main/python/dbschema/migrations/drop_user_tables.sql
+++ b/src/main/python/dbschema/migrations/drop_user_tables.sql
@@ -1,0 +1,14 @@
+/*
+ * This script will drop all tables whose data has been extracted to the User API (NED).
+ * When we are ready to drop formal support for these tables in a future release,
+ * change this script's name as appropriate and add it to migrations.json.
+ */
+
+drop table userOrcid;
+drop table userProfileMetaData;
+drop table savedSearch;
+drop table savedSearchQuery;
+drop table userSearch;
+drop table userLogin;
+drop table userArticleView;
+drop table userProfile;

--- a/src/main/python/dbschema/migrations/migrate_ambra_1009.sql
+++ b/src/main/python/dbschema/migrations/migrate_ambra_1009.sql
@@ -1,10 +1,1 @@
 alter table userProfileRoleJoinTable drop foreign key userProfileRoleJoinTable_ibfk_2;
-
-drop table userOrcid;
-drop table userProfileMetaData;
-drop table savedSearch;
-drop table savedSearchQuery;
-drop table userSearch;
-drop table userLogin;
-drop table userArticleView;
-drop table userProfile;


### PR DESCRIPTION
The file migrate_ambra_1009.sql in this repository was superseded by one in the Ambra base repository. Ours should now match; the lines removed from it are extracted to drop_user_tables.sql, awaiting a future release.
