### PR TITLE
DPRO-2654: Separate the use cases for ArticleRelationship in API

### DIFF
--- a/src/main/java/org/ambraproject/rhino/view/article/ArticleOutputView.java
+++ b/src/main/java/org/ambraproject/rhino/view/article/ArticleOutputView.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -127,7 +128,12 @@ public class ArticleOutputView implements JsonOutputView, ArticleView {
       KeyedListView<ArticleIssue> articleIssuesView = ArticleIssueOutputView.wrapList(articleIssues);
       serialized.add("issues", context.serialize(articleIssuesView));
 
-      serialized.add("relatedArticles", context.serialize(relatedArticles));
+      // Because they will have different fields, separate the two major use cases for ArticleRelationship:
+      // pointers to articles within our own corpus, and citations of external DOIs.
+      Collection<RelatedArticleView> relatedArticlesWithFrontMatter = Collections2.filter(relatedArticles, RelatedArticleView::hasFrontMatter);
+      serialized.add("relatedArticles", context.serialize(relatedArticlesWithFrontMatter));
+      Collection<RelatedArticleView> relatedArticlesWithDoiOnly = Collections2.filter(relatedArticles, ra -> !ra.hasFrontMatter());
+      serialized.add("relatedExternalArticles", context.serialize(relatedArticlesWithDoiOnly));
 
       serialized.add(MemberNames.PINGBACKS, context.serialize(pingbacks));
     }

--- a/src/main/java/org/ambraproject/rhino/view/article/RelatedArticleView.java
+++ b/src/main/java/org/ambraproject/rhino/view/article/RelatedArticleView.java
@@ -26,6 +26,10 @@ public class RelatedArticleView implements JsonOutputView, ArticleView {
     this.relatedArticle = Optional.ofNullable(relatedArticle);
   }
 
+  public boolean hasFrontMatter() {
+    return relatedArticle.isPresent();
+  }
+
   @Override
   public String getDoi() {
     return raw.getOtherArticleDoi();


### PR DESCRIPTION
I considered fixing this in Wombat, but every such way involved putting the same ugly hack in several places. Not only do several parts of code consume this data, but there are also checks for whether the list of related articles is empty (controlling section headers and such) that rule out a simple `if` check while iterating. Clearly a lower-level fix is needed.

Fixing it in Rhino seems appropriate anyway, because the underlying problem is that we shouldn't have objects with inconsistently nullable fields. That's why I feel good about separating the no-title relationships into their own list named `relatedExternalArticles` -- which, to be clear, we are ignoring for now and probably forever.

Those "external relationship" pointers are one of a few major ways in which `ArticleRelationship` is needlessly complicated. In the long run, we should probably just kill it; see [DPRO-2521](https://developer.plos.org/jira/browse/DPRO-2521).
