### PR TITLE
DPRO-2728: Replace "pages" field with "pageCount"

### DIFF
--- a/src/main/java/org/ambraproject/rhino/content/xml/ArticleXml.java
+++ b/src/main/java/org/ambraproject/rhino/content/xml/ArticleXml.java
@@ -184,7 +184,7 @@ public class ArticleXml extends AbstractArticleXml<ArticleMetadata> {
     }
     article.setRights(rights);
 
-    article.setPages(buildPages(readString("/article/front/article-meta/counts/page-count/@count")));
+    article.setPageCount(parsePageCount(readString("/article/front/article-meta/counts/page-count/@count")));
     article.seteLocationId(readString("/article/front/article-meta/elocation-id"));
     article.setVolume(readString("/article/front/article-meta/volume"));
     article.setIssue(readString("/article/front/article-meta/issue"));
@@ -255,11 +255,14 @@ public class ArticleXml extends AbstractArticleXml<ArticleMetadata> {
   /**
    * @return the appropriate value for the pages property of {@link ArticleMetadata}, based on the article XML.
    */
-  private static String buildPages(String pageCount) {
+  private static Integer parsePageCount(String pageCount) {
     if (Strings.isNullOrEmpty(pageCount)) {
       return null;
-    } else {
-      return "1-" + pageCount;
+    }
+    try {
+      return Integer.parseInt(pageCount);
+    } catch (NumberFormatException e) {
+      throw new XmlContentException("Expected number for page count", e);
     }
   }
 

--- a/src/main/java/org/ambraproject/rhino/model/article/ArticleMetadata.java
+++ b/src/main/java/org/ambraproject/rhino/model/article/ArticleMetadata.java
@@ -18,7 +18,7 @@ public class ArticleMetadata {
   private final String rights;
   private final String language;
   private final String format;
-  private final String pages;
+  private final Integer pageCount;
   private final String eLocationId;
 
   private final LocalDate publicationDate;
@@ -47,7 +47,7 @@ public class ArticleMetadata {
     this.rights = builder.rights;
     this.language = builder.language;
     this.format = builder.format;
-    this.pages = builder.pages;
+    this.pageCount = builder.pageCount;
     this.eLocationId = builder.eLocationId;
     this.publicationDate = builder.publicationDate;
     this.volume = builder.volume;
@@ -92,8 +92,8 @@ public class ArticleMetadata {
     return format;
   }
 
-  public String getPages() {
-    return pages;
+  public Integer getPageCount() {
+    return pageCount;
   }
 
   public String geteLocationId() {
@@ -169,7 +169,7 @@ public class ArticleMetadata {
     private String rights;
     private String language;
     private String format;
-    private String pages;
+    private Integer pageCount;
     private String eLocationId;
 
     private LocalDate publicationDate;
@@ -229,8 +229,8 @@ public class ArticleMetadata {
       return this;
     }
 
-    public Builder setPages(String pages) {
-      this.pages = pages;
+    public Builder setPageCount(Integer pageCount) {
+      this.pageCount = pageCount;
       return this;
     }
 
@@ -319,7 +319,7 @@ public class ArticleMetadata {
     if (rights != null ? !rights.equals(that.rights) : that.rights != null) return false;
     if (language != null ? !language.equals(that.language) : that.language != null) return false;
     if (format != null ? !format.equals(that.format) : that.format != null) return false;
-    if (pages != null ? !pages.equals(that.pages) : that.pages != null) return false;
+    if (pageCount != null ? !pageCount.equals(that.pageCount) : that.pageCount != null) return false;
     if (eLocationId != null ? !eLocationId.equals(that.eLocationId) : that.eLocationId != null) return false;
     if (publicationDate != null ? !publicationDate.equals(that.publicationDate) : that.publicationDate != null) {
       return false;
@@ -354,7 +354,7 @@ public class ArticleMetadata {
     result = 31 * result + (rights != null ? rights.hashCode() : 0);
     result = 31 * result + (language != null ? language.hashCode() : 0);
     result = 31 * result + (format != null ? format.hashCode() : 0);
-    result = 31 * result + (pages != null ? pages.hashCode() : 0);
+    result = 31 * result + (pageCount != null ? pageCount.hashCode() : 0);
     result = 31 * result + (eLocationId != null ? eLocationId.hashCode() : 0);
     result = 31 * result + (publicationDate != null ? publicationDate.hashCode() : 0);
     result = 31 * result + (volume != null ? volume.hashCode() : 0);


### PR DESCRIPTION
This removes an unused extra step on top of what is provided in the manuscript.

As far as I can tell, in the one place we are using this value, we use a regular expression to parse the "1-" off anyway. If we ever discover another need to format it as "1-x", we should append that in the display layer.
