### PR TITLE
DPRO-2833: Make article type nullable

### DIFF
--- a/src/main/java/org/ambraproject/rhino/content/xml/ArticleXml.java
+++ b/src/main/java/org/ambraproject/rhino/content/xml/ArticleXml.java
@@ -288,10 +288,10 @@ public class ArticleXml extends AbstractArticleXml<ArticleMetadata> {
   private String parseArticleHeading() {
     List<String> headings = readTextList("/article/front/article-meta/article-categories/"
         + "subj-group[@subj-group-type = 'heading']/subject");
-    if (headings.size() != 1) {
-      throw new XmlContentException("Must contain exactly one subject group with subj-group-type=\"heading\"");
+    if (headings.size() > 1) {
+      throw new XmlContentException("Must not contain more than one subject group with subj-group-type=\"heading\"");
     }
-    return headings.get(0);
+    return headings.isEmpty() ? null : headings.get(0);
   }
 
 

--- a/src/main/python/dbschema/migrations/versioning-prototype.sql
+++ b/src/main/python/dbschema/migrations/versioning-prototype.sql
@@ -12,7 +12,7 @@ CREATE TABLE `articleIngestion` (
   `ingestionNumber` INT NOT NULL,
   `title` TEXT NOT NULL,
   `publicationDate` DATE NOT NULL,
-  `articleType` VARCHAR(100) NOT NULL,
+  `articleType` VARCHAR(100) DEFAULT NULL,
   `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `lastModified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`ingestionId`),


### PR DESCRIPTION
It's not 100% clear to me that we have a formal spec either way, but this seems like the safest option. We probably have a few manuscripts without type headings in the corpus somewhere, and an open-source user might not want to bother with the type system anyway.
