### PR TITLE
DPRO-2866: Change lists API to be consistent with others

### DIFF
--- a/src/main/java/org/ambraproject/rhino/rest/controller/ArticleListCrudController.java
+++ b/src/main/java/org/ambraproject/rhino/rest/controller/ArticleListCrudController.java
@@ -63,7 +63,7 @@ public class ArticleListCrudController extends RestController {
   }
 
   @Transactional(rollbackFor = {Throwable.class})
-  @RequestMapping(value = "/lists/{type}/{journal}/{key}", method = RequestMethod.PATCH)
+  @RequestMapping(value = "/lists/{type}/journals/{journal}/keys/{key}", method = RequestMethod.PATCH)
   public ResponseEntity<?> update(HttpServletRequest request,
                                   @PathVariable("type") String type,
                                   @PathVariable("journal") String journalKey,
@@ -100,7 +100,7 @@ public class ArticleListCrudController extends RestController {
   }
 
   @Transactional(rollbackFor = {Throwable.class})
-  @RequestMapping(value = "/lists/{type}/{journal}", method = RequestMethod.GET)
+  @RequestMapping(value = "/lists/{type}/journals/{journal}", method = RequestMethod.GET)
   public void listAll(HttpServletRequest request, HttpServletResponse response,
                       @PathVariable("type") String type,
                       @PathVariable("journal") String journalKey)
@@ -109,7 +109,7 @@ public class ArticleListCrudController extends RestController {
   }
 
   @Transactional(rollbackFor = {Throwable.class})
-  @RequestMapping(value = "/lists/{type}/{journal}/{key}", method = RequestMethod.GET)
+  @RequestMapping(value = "/lists/{type}/journals/{journal}/keys/{key}", method = RequestMethod.GET)
   public void read(HttpServletRequest request, HttpServletResponse response,
                    @PathVariable("type") String type,
                    @PathVariable("journal") String journalKey,


### PR DESCRIPTION
The actual API change is not set in stone yet.

Two things to consider:
1. It's possible that "journals", instead of appearing in the middle, should be merged with the regular, root "journals" noun. But we would still need a root-level "lists" noun: see lines 88 and 95.
2. Putting "lists" as the root noun is kind of misleading, because the identifier that immediately follows it is not a list for a list type. Similarly, "keys" is a little wrong because the key that follows it is the name of a list, not the name of a key. You could argue that it should be `/listTypes/{type}/journals/{journal}/lists/{key}` but somehow it seems less friendly without "lists" as the root noun.
