### PR TITLE
DPRO-2931: Change file type requirements for stand-alone striking images

### DIFF
--- a/src/main/java/org/ambraproject/rhino/model/ingest/AssetType.java
+++ b/src/main/java/org/ambraproject/rhino/model/ingest/AssetType.java
@@ -66,11 +66,9 @@ public enum AssetType {
   },
 
   STANDALONE_STRIKING_IMAGE {
-    private final ImmutableSet<FileType> TYPES = Sets.immutableEnumSet(FileType.STRIKING_IMAGE);
-
     @Override
     protected ImmutableSet<FileType> getSupportedFileTypes() {
-      return TYPES;
+      return STANDARD_THUMBNAIL_FILE_TYPES;
     }
   };
 

--- a/src/main/java/org/ambraproject/rhino/model/ingest/FileType.java
+++ b/src/main/java/org/ambraproject/rhino/model/ingest/FileType.java
@@ -27,10 +27,7 @@ public enum FileType {
   SMALL, MEDIUM, INLINE, LARGE,
 
   // A supplementary information file, which should always be the only file with its DOI
-  SUPPLEMENTARY,
-
-  // An image that is used only as a striking image and is not otherwise part of the article
-  STRIKING_IMAGE;
+  SUPPLEMENTARY;
 
   private final String identifier = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, name());
 


### PR DESCRIPTION
Stand-alone striking images should require the same loadout of
pre-generated thumbnails as a figure, because they will be displayed
interchangeably with figures. The concept of a single file representing a
striking image is not valid under the input spec and should have been
removed a while ago.
