### PR TITLE
DPRO-2863: Add DOI to ItemView

### DIFF
--- a/src/main/java/org/ambraproject/rhino/view/article/versioned/ItemSetView.java
+++ b/src/main/java/org/ambraproject/rhino/view/article/versioned/ItemSetView.java
@@ -66,10 +66,12 @@ public class ItemSetView {
   }
 
   public static class ItemView {
+    private final String doi;
     private final String itemType;
     private final ImmutableMap<String, FileView> files;
 
     private ItemView(ArticleItem item, Collection<ArticleFile> files) {
+      this.doi = Objects.requireNonNull(item.getDoi());
       this.itemType = Objects.requireNonNull(item.getItemType());
       this.files = ImmutableMap.copyOf(files.stream()
           .collect(Collectors.toMap(ArticleFile::getFileType, FileView::new)));


### PR DESCRIPTION
In the original ItemSetView it wasn't strictly needed because it was a map
key. But the view is now used for the ingestion view's "strikingImage"
field and there is no other way to get the item DOI there.
