### PR TITLE
DPRO-382: Delete overzealous argument check

### DIFF
--- a/src/main/java/org/ambraproject/rhino/rest/response/ServiceResponse.java
+++ b/src/main/java/org/ambraproject/rhino/rest/response/ServiceResponse.java
@@ -1,6 +1,5 @@
 package org.ambraproject.rhino.rest.response;
 
-import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -36,7 +35,6 @@ public class ServiceResponse<T> {
     this.status = Objects.requireNonNull(status);
     this.body = body;
     this.lastModified = lastModified;
-    Preconditions.checkArgument(body != null || lastModified == null);
   }
 
   /**


### PR DESCRIPTION
It made sense in an earlier iteration when ServiceResponse objects were not
being constructed by CacheableResponse.getIfModified.