### PR TITLE
DPRO-3286: Add readme explaining Debian packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -592,6 +592,7 @@
       </plugin>
 
         <plugin>
+          <!-- See src/deb/README.md -->
             <artifactId>jdeb</artifactId>
             <groupId>org.vafer</groupId>
             <version>1.5</version>

--- a/src/deb/README.md
+++ b/src/deb/README.md
@@ -1,0 +1,14 @@
+This directory specifies Debian packages that currently are being used, on a
+prototype basis, for deployments within PLOS. This project does not distribute
+any public Debian packages, but may do so in the future.
+
+The recommended method to obtain this program is as a `.war` file, from the
+Ambra Project's [Releases][release] page. For deployment instructions, see the
+[Quickstart Guide][quickstart].
+
+  [release]:    https://plos.github.io/ambraproject/Releases.html
+  [quickstart]: https://plos.github.io/ambraproject/Quickstart-Guide.html
+
+If you compile from source with `mvn install`, you will find a `*.deb` file in
+the `target/` directory. Unless you are a PLOS developer, ignore it and use the
+`*.war` file instead.


### PR DESCRIPTION
To clarify about the (absence of) public Debian packages for open-source users.

Per @johnfesenko's and my earlier conversation, it would be even better if we could set it up so that Maven produces the `*.deb` file only if a special goal is used (i.e., not every time you do `mvn install`).