### PR TITLE
DPRO-3408: Use new DOI style for "url" metadata parameter

### DIFF
--- a/src/main/java/org/ambraproject/rhino/content/xml/ArticleXml.java
+++ b/src/main/java/org/ambraproject/rhino/content/xml/ArticleXml.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
-import java.net.URLEncoder;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Comparator;
@@ -169,7 +168,8 @@ public class ArticleXml extends AbstractArticleXml<ArticleMetadata> {
   }
 
   private void setFromXml(final ArticleMetadata.Builder article) throws XmlContentException {
-    article.setDoi(readDoi().getName());
+    Doi doi = readDoi();
+    article.setDoi(doi.getName());
 
     article.setTitle(getXmlFromNode(readNode("/article/front/article-meta/title-group/article-title")));
     String eissn = readString("/article/front/journal-meta/issn[@pub-type=\"epub\"]");
@@ -206,7 +206,7 @@ public class ArticleXml extends AbstractArticleXml<ArticleMetadata> {
     article.setEditors(readPersons(readNodeList(
         "/article/front/article-meta/contrib-group/contrib[@contrib-type=\"editor\"]/name")));
 
-    article.setUrl(buildUrl(readString("/article/front/article-meta/article-id[@pub-id-type = 'doi']")));
+    article.setUrl(buildUrl(doi));
 
     article.setRelatedArticles(parseRelatedArticles());
 
@@ -270,10 +270,10 @@ public class ArticleXml extends AbstractArticleXml<ArticleMetadata> {
   }
 
   /**
-   * @return a valid URL to the article (base on the DOI)
+   * @return a valid URL to the article (based on the DOI)
    */
-  private static String buildUrl(String doi) {
-    return "http://dx.doi.org/" + URLEncoder.encode(doi);
+  private static String buildUrl(Doi doi) {
+    return doi.asUri(Doi.UriStyle.HTTPS_DOI_RESOLVER).toString();
   }
 
   private String parseArticleHeading() {

--- a/src/main/java/org/ambraproject/rhino/identity/Doi.java
+++ b/src/main/java/org/ambraproject/rhino/identity/Doi.java
@@ -46,28 +46,51 @@ import java.util.Locale;
 public final class Doi {
 
   public static enum UriStyle {
+    /**
+     * Formerly the standard Ambra style. Required by some legacy code.
+     */
     INFO_DOI("info:doi/") {
       @Override
       protected URI convert(String doiName) throws URISyntaxException {
         return new URI("info", "doi/" + doiName, null);
       }
     },
+
     DOI_SCHEME("doi:") {
       @Override
       protected URI convert(String doiName) throws URISyntaxException {
         return new URI("doi", doiName, null);
       }
     },
-    HTTP_RESOLVER("http://dx.doi.org/") {
+
+    /**
+     * Currently Crossref's standard style.
+     */
+    HTTPS_DOI_RESOLVER("https://doi.org/") {
       @Override
       protected URI convert(String doiName) throws URISyntaxException, MalformedURLException {
-        return new URL("http", "dx.doi.org/", doiName).toURI();
+        return new URL("https", "doi.org/", doiName).toURI();
       }
     },
-    HTTPS_RESOLVER("https://dx.doi.org/") {
+
+    HTTP_DOI_RESOLVER("http://doi.org/") {
+      @Override
+      protected URI convert(String doiName) throws URISyntaxException, MalformedURLException {
+        return new URL("http", "doi.org/", doiName).toURI();
+      }
+    },
+
+    HTTPS_DX_RESOLVER("https://dx.doi.org/") {
       @Override
       protected URI convert(String doiName) throws URISyntaxException, MalformedURLException {
         return new URL("https", "dx.doi.org/", doiName).toURI();
+      }
+    },
+
+    HTTP_DX_RESOLVER("http://dx.doi.org/") {
+      @Override
+      protected URI convert(String doiName) throws URISyntaxException, MalformedURLException {
+        return new URL("http", "dx.doi.org/", doiName).toURI();
       }
     };
 


### PR DESCRIPTION
Factored out duplication so that the Doi class formats the URL.