### PR TITLE
DPRO-3491: exclude article metadata for root articleList GET

### DIFF
--- a/src/main/java/org/ambraproject/rhino/rest/controller/ArticleListCrudController.java
+++ b/src/main/java/org/ambraproject/rhino/rest/controller/ArticleListCrudController.java
@@ -116,14 +116,14 @@ public class ArticleListCrudController extends RestController {
   @Transactional(rollbackFor = {Throwable.class})
   @RequestMapping(value = "/lists", method = RequestMethod.GET)
   public ResponseEntity<?> listAll() throws IOException {
-    return articleListCrudService.readAll(Optional.empty(), Optional.empty()).asJsonResponse(entityGson);
+    return articleListCrudService.readAll().asJsonResponse(entityGson);
   }
 
   @Transactional(rollbackFor = {Throwable.class})
   @RequestMapping(value = "/lists/{type}", method = RequestMethod.GET)
   public ResponseEntity<?> listAll(@PathVariable("type") String type)
       throws IOException {
-    return articleListCrudService.readAll(Optional.of(type), Optional.empty()).asJsonResponse(entityGson);
+    return articleListCrudService.readAll(type, Optional.empty()).asJsonResponse(entityGson);
   }
 
   @Transactional(rollbackFor = {Throwable.class})
@@ -131,7 +131,7 @@ public class ArticleListCrudController extends RestController {
   public ResponseEntity<?> listAll(@PathVariable("type") String type,
                                    @PathVariable("journal") String journalKey)
       throws IOException {
-    return articleListCrudService.readAll(Optional.of(type), Optional.of(journalKey)).asJsonResponse(entityGson);
+    return articleListCrudService.readAll(type, Optional.of(journalKey)).asJsonResponse(entityGson);
   }
 
   @Transactional(rollbackFor = {Throwable.class})

--- a/src/main/java/org/ambraproject/rhino/service/ArticleListCrudService.java
+++ b/src/main/java/org/ambraproject/rhino/service/ArticleListCrudService.java
@@ -48,7 +48,17 @@ public interface ArticleListCrudService {
 
   ServiceResponse<ArticleListView> read(ArticleListIdentity identity);
 
-  ServiceResponse<Collection<ArticleListView>> readAll(Optional<String> listType, Optional<String> journalKey);
+  /**
+   * @return the identities of all lists, excluding article metadata
+   */
+  ServiceResponse<Collection<ArticleListView>> readAll();
+
+  /**
+   * @param listType   the type of list to create
+   * @param journalKey the journal the list belongs to
+   * @return the identities of all lists, and all article metadata for all returned lists
+   */
+  ServiceResponse<Collection<ArticleListView>> readAll(String listType, Optional<String> journalKey);
 
   /**
    * Read all lists that contain the article.

--- a/src/main/java/org/ambraproject/rhino/service/impl/ArticleListCrudServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/ArticleListCrudServiceImpl.java
@@ -35,7 +35,6 @@ import org.ambraproject.rhino.rest.RestClientException;
 import org.ambraproject.rhino.rest.response.ServiceResponse;
 import org.ambraproject.rhino.service.ArticleListCrudService;
 import org.ambraproject.rhino.view.journal.ArticleListView;
-import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
@@ -45,11 +44,9 @@ import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.orm.hibernate3.HibernateCallback;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,12 +69,9 @@ public class ArticleListCrudServiceImpl extends AmbraService implements ArticleL
   }
 
   private boolean listExists(final ArticleListIdentity identity) {
-    long count = hibernateTemplate.execute(new HibernateCallback<Long>() {
-      @Override
-      public Long doInHibernate(Session session) throws HibernateException, SQLException {
-        Query query = queryFor(session, "select count(*)", identity);
-        return (Long) query.uniqueResult();
-      }
+    long count = hibernateTemplate.execute(session -> {
+      Query query = queryFor(session, "select count(*)", identity);
+      return (Long) query.uniqueResult();
     });
     return count > 0L;
   }
@@ -112,13 +106,11 @@ public class ArticleListCrudServiceImpl extends AmbraService implements ArticleL
   }
 
   private ArticleListView getArticleList(final ArticleListIdentity identity) {
-    Object[] result = DataAccessUtils.uniqueResult(hibernateTemplate.execute(new HibernateCallback<List<Object[]>>() {
-      @Override
-      public List<Object[]> doInHibernate(Session session) throws HibernateException, SQLException {
-        Query query = queryFor(session, "select j.journalKey, l", identity);
-        return query.list();
-      }
-    }));
+    Object[] result = DataAccessUtils.uniqueResult(hibernateTemplate
+        .execute((HibernateCallback<List<Object[]>>) session -> {
+          Query query = queryFor(session, "select j.journalKey, l", identity);
+          return query.list();
+        }));
     if (result == null) {
       throw nonexistentList(identity);
     }
@@ -174,14 +166,11 @@ public class ArticleListCrudServiceImpl extends AmbraService implements ArticleL
       throw new RestClientException(buildMissingArticleMessage(articles, articleKeys.keySet()), HttpStatus.NOT_FOUND);
     }
 
-    Collections.sort(articles, new Comparator<Article>() {
-      @Override
-      public int compare(Article o1, Article o2) {
-        // We expect the error check above to guarantee that both values will be found in the map
-        int i1 = articleKeys.get(o1.getDoi());
-        int i2 = articleKeys.get(o2.getDoi());
-        return i1 - i2;
-      }
+    Collections.sort(articles, (a1, a2) -> {
+      // We expect the error check above to guarantee that both values will be found in the map
+      int i1 = articleKeys.get(a1.getDoi());
+      int i2 = articleKeys.get(a2.getDoi());
+      return i1 - i2;
     });
 
     return articles;
@@ -205,59 +194,64 @@ public class ArticleListCrudServiceImpl extends AmbraService implements ArticleL
   }
 
   private Collection<ArticleListView> asArticleListViews(List<Object[]> results) {
+    return asArticleListViews(results, false /*excludeArticleMetadata*/);
+  }
+
+  private Collection<ArticleListView> asArticleListViews(List<Object[]> results, boolean excludeArticleMetadata) {
     Collection<ArticleListView> views = new ArrayList<>(results.size());
     for (Object[] result : results) {
       String journalKey = (String) result[0];
       ArticleList articleList = (ArticleList) result[1];
-      views.add(articleListViewFactory.getView(articleList, journalKey));
+      views.add(articleListViewFactory.getView(articleList, journalKey, excludeArticleMetadata));
     }
     return views;
   }
 
   @Override
-  public ServiceResponse<Collection<ArticleListView>> readAll(final Optional<String> listType, final Optional<String> journalKey) {
-    if (!listType.isPresent() && journalKey.isPresent()) {
-      throw new IllegalArgumentException();
-    }
-    List<Object[]> result = hibernateTemplate.execute(new HibernateCallback<List<Object[]>>() {
-      @Override
-      public List<Object[]> doInHibernate(Session session) throws HibernateException, SQLException {
-        StringBuilder queryString = new StringBuilder(125)
-            .append("select j.journalKey, l from Journal j inner join j.articleLists l");
-        if (listType.isPresent()) {
-          queryString.append(" where (l.listType=:listType)");
-          if (journalKey.isPresent()) {
-            queryString.append(" and (j.journalKey=:journalKey)");
-          }
-        }
+  public ServiceResponse<Collection<ArticleListView>> readAll(final String listType, final Optional<String> journalKey) {
 
-        Query query = session.createQuery(queryString.toString());
-        if (listType.isPresent()) {
-          query.setParameter("listType", listType.get());
-          if (journalKey.isPresent()) {
-            query.setParameter("journalKey", journalKey.get());
-          }
-        }
+    List<Object[]> result = hibernateTemplate.execute((HibernateCallback<List<Object[]>>) session -> {
+      StringBuilder queryString = new StringBuilder(125)
+          .append("select j.journalKey, l from Journal j inner join j.articleLists l");
 
-        return query.list();
+      queryString.append(" where (l.listType=:listType)");
+      if (journalKey.isPresent()) {
+        queryString.append(" and (j.journalKey=:journalKey)");
       }
+
+      Query query = session.createQuery(queryString.toString());
+
+      query.setParameter("listType", listType);
+      if (journalKey.isPresent()) {
+        query.setParameter("journalKey", journalKey.get());
+      }
+
+      return query.list();
     });
     Collection<ArticleListView> views = asArticleListViews(result);
     return ServiceResponse.serveView(views);
   }
 
+  @Override
+  public ServiceResponse<Collection<ArticleListView>> readAll() {
+
+    List<Object[]> result = hibernateTemplate.execute((HibernateCallback<List<Object[]>>) session -> {
+      Query query = session.createQuery("select j.journalKey, l from Journal j inner join j.articleLists l");
+      return query.list();
+    });
+    Collection<ArticleListView> views = asArticleListViews(result, true /*excludeArticleMetadata*/);
+    return ServiceResponse.serveView(views);
+  }
+
   private Collection<ArticleListView> findContainingLists(final ArticleIdentifier articleId) {
-    return hibernateTemplate.execute(new HibernateCallback<Collection<ArticleListView>>() {
-      @Override
-      public Collection<ArticleListView> doInHibernate(Session session) {
-        Query query = session.createQuery("" +
-            "select j.journalKey, l " +
-            "from Journal j join j.articleLists l join l.articles a " +
-            "where a.doi=:doi");
-        query.setString("doi", articleId.getDoiName());
-        List<Object[]> results = query.list();
-        return asArticleListViews(results);
-      }
+    return hibernateTemplate.execute(session -> {
+      Query query = session.createQuery("" +
+          "select j.journalKey, l " +
+          "from Journal j join j.articleLists l join l.articles a " +
+          "where a.doi=:doi");
+      query.setString("doi", articleId.getDoiName());
+      List<Object[]> results = query.list();
+      return asArticleListViews(results);
     });
   }
 

--- a/src/main/java/org/ambraproject/rhino/view/journal/ArticleListView.java
+++ b/src/main/java/org/ambraproject/rhino/view/journal/ArticleListView.java
@@ -43,17 +43,31 @@ public class ArticleListView implements JsonOutputView {
     public ArticleListView getView(ArticleList articleList, String journalKey) {
       return new ArticleListView(journalKey, articleList, articleRevisionViewFactory);
     }
+
+    public ArticleListView getView(ArticleList articleList, String journalKey, boolean excludeArticleMetadata) {
+      return new ArticleListView(journalKey, articleList, articleRevisionViewFactory, excludeArticleMetadata);
+    }
   }
 
   private final String journalKey;
   private final ArticleList articleList;
   private final ArticleRevisionView.Factory articleFactory;
+  private final boolean excludeArticleMetadata;
 
   private ArticleListView(String journalKey, ArticleList articleList,
                           ArticleRevisionView.Factory articleFactory) {
     this.journalKey = Objects.requireNonNull(journalKey);
     this.articleList = Objects.requireNonNull(articleList);
     this.articleFactory = Objects.requireNonNull(articleFactory);
+    this.excludeArticleMetadata = false;
+  }
+
+  private ArticleListView(String journalKey, ArticleList articleList,
+                          ArticleRevisionView.Factory articleFactory, boolean excludeArticleMetadata) {
+    this.journalKey = Objects.requireNonNull(journalKey);
+    this.articleList = Objects.requireNonNull(articleList);
+    this.articleFactory = Objects.requireNonNull(articleFactory);
+    this.excludeArticleMetadata = excludeArticleMetadata;
   }
 
   public ArticleListIdentity getIdentity() {
@@ -72,9 +86,11 @@ public class ArticleListView implements JsonOutputView {
     JsonObject serialized = context.serialize(getIdentity()).getAsJsonObject();
     serialized.addProperty("title", articleList.getDisplayName());
 
-    List<ArticleRevisionView> articleViews = Lists.transform(articleList.getArticles(),
-        articleFactory::getLatestRevisionView);
-    serialized.add("articles", context.serialize(articleViews));
+    if (!excludeArticleMetadata) {
+      List<ArticleRevisionView> articleViews = Lists.transform(articleList.getArticles(),
+          articleFactory::getLatestRevisionView);
+      serialized.add("articles", context.serialize(articleViews));
+    }
     return serialized;
   }
 


### PR DESCRIPTION
@sbassi  since you're still new to Java let me explain what I am doing in this change.

We return JSON from Rhino. The problem here is that we were returning too much JSON data, causing the request to time out.

Until we truly need pagination, we should instead decrease the amount of JSON we return from Rhino. In this case, we do no need to include article information. Wombat does not make use of the root GET endpoint, but Lemur does. @cabanalabs is filing a ticket to look at the Lemur implementation and make sure they do not require the article metadata. If they do require the article metadata, they will have to make the request in a more specific way.

We control the JSON output from Rhino in "View" classes kept in /view/.

To fix this problem, I decided to exclude the article metadata from by adding a new method and a new boolean variable, ultimately controlling the output of ```ArticleListView```. Wombat does require the article metadata in the more-specific call it makes to Rhino for article lists, so only the root GET endpoint excludes article metadata. 

We had a similar problem with article revisions - Wombat volumes and issue GET calls would time out if too many revisions were in included in the volume's issues. Instead of excluding data like we did in this case, we created a new class named ```ArticleOverview``` which serves less data. If article lists were more complex, we would have instead created a new class, as we did with ```ArticleOverview```.