### PR TITLE
Upgrade to tomcat7 maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,8 +496,8 @@
 
       <plugin>
         <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat6-maven-plugin</artifactId>
-        <version>2.1</version>
+        <artifactId>tomcat7-maven-plugin</artifactId>
+        <version>2.2</version>
         <configuration>
           <path>/</path>
           <contextFile>${rhino.configDir}/context.xml</contextFile>


### PR DESCRIPTION
We use tomcat 7 in production, we should upgrade the maven plugin used for testing.