### PR TITLE
Remove boilerplate with ActiveObject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,12 @@
       <artifactId>swagger-springmvc</artifactId>
       <version>0.8.8</version>
     </dependency>
-
+    <dependency>
+    	<groupId>com.google.auto.value</groupId>
+    	<artifactId>auto-value</artifactId>
+    	<version>1.5</version>
+    	<scope>provided</scope>
+    </dependency>
   </dependencies>
 
 

--- a/src/main/java/org/ambraproject/rhino/model/article/ArticleMetadata.java
+++ b/src/main/java/org/ambraproject/rhino/model/article/ArticleMetadata.java
@@ -23,373 +23,73 @@
 package org.ambraproject.rhino.model.article;
 
 import com.google.common.collect.ImmutableList;
+import com.google.auto.value.AutoValue;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Objects;
+import javax.annotation.Nullable;
 
-public class ArticleMetadata {
+@AutoValue
+public abstract class ArticleMetadata {
 
-  private final String doi;
+  @Nullable public abstract String getDoi();
 
-  private final String title;
-  private final String eIssn;
-  private final String journalName;
-  private final String description;
-  private final String abstractText;
-  private final String rights;
-  private final String language;
-  private final String format;
-  private final Integer pageCount;
-  private final String eLocationId;
+  @Nullable public abstract String getTitle();
+  @Nullable public abstract String getEissn();
+  @Nullable public abstract String getJournalName();
+  @Nullable public abstract String getDescription();
+  @Nullable public abstract String getAbstractText();
+  @Nullable public abstract String getRights();
+  @Nullable public abstract String getLanguage();
+  @Nullable public abstract String getFormat();
+  @Nullable public abstract Integer getPageCount();
+  @Nullable public abstract String geteLocationId();
 
-  private final LocalDate publicationDate;
+  @Nullable public abstract LocalDate getPublicationDate();
 
-  private final String volume;
-  private final String issue;
+  @Nullable public abstract String getVolume();
+  @Nullable public abstract String getIssue();
 
-  private final String publisherLocation;
-  private final String publisherName;
-  private final String url;
+  @Nullable public abstract String getPublisherLocation();
+  @Nullable public abstract String getPublisherName();
+  @Nullable public abstract String getUrl();
 
-  private final String nlmArticleType;
-  private final String articleType;
+  @Nullable public abstract String getNlmArticleType();
+  @Nullable public abstract String getArticleType();
 
-  private final ImmutableList<AssetMetadata> assets;
-  private final ImmutableList<RelatedArticleLink> relatedArticles;
-  private final ImmutableList<NlmPerson> editors;
-
-  private ArticleMetadata(Builder builder) {
-    this.doi = Objects.requireNonNull(builder.doi);
-    this.title = builder.title;
-    this.eIssn = builder.eIssn;
-    this.journalName = builder.journalName;
-    this.description = builder.description;
-    this.abstractText = builder.abstractText;
-    this.rights = builder.rights;
-    this.language = builder.language;
-    this.format = builder.format;
-    this.pageCount = builder.pageCount;
-    this.eLocationId = builder.eLocationId;
-    this.publicationDate = builder.publicationDate;
-    this.volume = builder.volume;
-    this.issue = builder.issue;
-    this.publisherLocation = builder.publisherLocation;
-    this.publisherName = builder.publisherName;
-    this.url = builder.url;
-    this.nlmArticleType = builder.nlmArticleType;
-    this.articleType = builder.articleType;
-    this.assets = ImmutableList.copyOf(builder.assets);
-    this.relatedArticles = ImmutableList.copyOf(builder.relatedArticles);
-    this.editors = ImmutableList.copyOf(builder.editors);
-  }
-
-  public String getDoi() {
-    return doi;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public String getEissn() {
-    return eIssn;
-  }
-
-  public String getJournalName() {
-    return journalName;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public String getAbstractText() {
-    return abstractText;
-  }
-
-  public String getRights() {
-    return rights;
-  }
-
-  public String getLanguage() {
-    return language;
-  }
-
-  public String getFormat() {
-    return format;
-  }
-
-  public Integer getPageCount() {
-    return pageCount;
-  }
-
-  public String geteLocationId() {
-    return eLocationId;
-  }
-
-  public LocalDate getPublicationDate() {
-    return publicationDate;
-  }
-
-  public String getVolume() {
-    return volume;
-  }
-
-  public String getIssue() {
-    return issue;
-  }
-
-  public String getPublisherLocation() {
-    return publisherLocation;
-  }
-
-  public String getPublisherName() {
-    return publisherName;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public String getNlmArticleType() {
-    return nlmArticleType;
-  }
-
-  public String getArticleType() {
-    return articleType;
-  }
-
-  public ImmutableList<AssetMetadata> getAssets() {
-    return assets;
-  }
-
-  public ImmutableList<RelatedArticleLink> getRelatedArticles() {
-    return relatedArticles;
-  }
-
-  public ImmutableList<NlmPerson> getEditors() {
-    return editors;
-  }
-
+  @Nullable public abstract ImmutableList<AssetMetadata> getAssets();
+  @Nullable public abstract ImmutableList<RelatedArticleLink> getRelatedArticles();
+  @Nullable public abstract ImmutableList<NlmPerson> getEditors();
 
   public static Builder builder() {
-    return new Builder();
+    return new AutoValue_ArticleMetadata.Builder();
   }
 
-  public static class Builder {
-    private Builder() {
-    }
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract ArticleMetadata build();
 
-    private String doi;
-
-    private String title;
-    private String eIssn;
-    private String journalName;
-    private String description;
-    private String abstractText;
-    private String rights;
-    private String language;
-    private String format;
-    private Integer pageCount;
-    private String eLocationId;
-
-    private LocalDate publicationDate;
-
-    private String volume;
-    private String issue;
-
-    private String publisherLocation;
-    private String publisherName;
-    private String url;
-
-    private String nlmArticleType;
-    private String articleType;
-
-    private List<AssetMetadata> assets;
-    private List<RelatedArticleLink> relatedArticles;
-    private List<NlmPerson> editors;
-
-    public ArticleMetadata build() {
-      return new ArticleMetadata(this);
-    }
-
-    public Builder setDoi(String doi) {
-      this.doi = doi;
-      return this;
-    }
-
-    public Builder setTitle(String title) {
-      this.title = title;
-      return this;
-    }
-
-    public Builder setEissn(String eIssn) {
-      this.eIssn = eIssn;
-      return this;
-    }
-
-    public void setJournalName(String journalName) {
-      this.journalName = journalName;
-    }
-
-    public Builder setDescription(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public Builder setAbstractText(String abstractText) {
-      this.abstractText = abstractText;
-      return this;
-    }
-
-    public Builder setRights(String rights) {
-      this.rights = rights;
-      return this;
-    }
-
-    public Builder setLanguage(String language) {
-      this.language = language;
-      return this;
-    }
-
-    public Builder setFormat(String format) {
-      this.format = format;
-      return this;
-    }
-
-    public Builder setPageCount(Integer pageCount) {
-      this.pageCount = pageCount;
-      return this;
-    }
-
-    public Builder seteLocationId(String eLocationId) {
-      this.eLocationId = eLocationId;
-      return this;
-    }
-
-    public Builder setPublicationDate(LocalDate publicationDate) {
-      this.publicationDate = publicationDate;
-      return this;
-    }
-
-    public Builder setVolume(String volume) {
-      this.volume = volume;
-      return this;
-    }
-
-    public Builder setIssue(String issue) {
-      this.issue = issue;
-      return this;
-    }
-
-    public Builder setPublisherLocation(String publisherLocation) {
-      this.publisherLocation = publisherLocation;
-      return this;
-    }
-
-    public Builder setPublisherName(String publisherName) {
-      this.publisherName = publisherName;
-      return this;
-    }
-
-    public Builder setUrl(String url) {
-      this.url = url;
-      return this;
-    }
-
-    public Builder setNlmArticleType(String nlmArticleType) {
-      this.nlmArticleType = nlmArticleType;
-      return this;
-    }
-
-    public Builder setArticleType(String articleType) {
-      this.articleType = articleType;
-      return this;
-    }
-
-    public Builder setAssets(List<AssetMetadata> assets) {
-      this.assets = assets;
-      return this;
-    }
-
-    public Builder setRelatedArticles(List<RelatedArticleLink> relatedArticles) {
-      this.relatedArticles = relatedArticles;
-      return this;
-    }
-
-    public Builder setEditors(List<NlmPerson> editors) {
-      this.editors = editors;
-      return this;
-    }
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    ArticleMetadata that = (ArticleMetadata) o;
-
-    if (doi != null ? !doi.equals(that.doi) : that.doi != null) return false;
-    if (title != null ? !title.equals(that.title) : that.title != null) return false;
-    if (eIssn != null ? !eIssn.equals(that.eIssn) : that.eIssn != null) return false;
-    if (journalName != null ? !journalName.equals(that.journalName) : that.journalName != null)
-      return false;
-    if (description != null ? !description.equals(that.description) : that.description != null)
-      return false;
-    if (abstractText != null ? !abstractText.equals(that.abstractText) : that.abstractText != null)
-      return false;
-    if (rights != null ? !rights.equals(that.rights) : that.rights != null) return false;
-    if (language != null ? !language.equals(that.language) : that.language != null) return false;
-    if (format != null ? !format.equals(that.format) : that.format != null) return false;
-    if (pageCount != null ? !pageCount.equals(that.pageCount) : that.pageCount != null)
-      return false;
-    if (eLocationId != null ? !eLocationId.equals(that.eLocationId) : that.eLocationId != null)
-      return false;
-    if (publicationDate != null ? !publicationDate.equals(that.publicationDate) : that.publicationDate != null)
-      return false;
-    if (volume != null ? !volume.equals(that.volume) : that.volume != null) return false;
-    if (issue != null ? !issue.equals(that.issue) : that.issue != null) return false;
-    if (publisherLocation != null ? !publisherLocation.equals(that.publisherLocation) : that.publisherLocation != null)
-      return false;
-    if (publisherName != null ? !publisherName.equals(that.publisherName) : that.publisherName != null)
-      return false;
-    if (url != null ? !url.equals(that.url) : that.url != null) return false;
-    if (nlmArticleType != null ? !nlmArticleType.equals(that.nlmArticleType) : that.nlmArticleType != null)
-      return false;
-    if (articleType != null ? !articleType.equals(that.articleType) : that.articleType != null)
-      return false;
-    if (assets != null ? !assets.equals(that.assets) : that.assets != null) return false;
-    if (relatedArticles != null ? !relatedArticles.equals(that.relatedArticles) : that.relatedArticles != null)
-      return false;
-    return editors != null ? editors.equals(that.editors) : that.editors == null;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = doi != null ? doi.hashCode() : 0;
-    result = 31 * result + (title != null ? title.hashCode() : 0);
-    result = 31 * result + (eIssn != null ? eIssn.hashCode() : 0);
-    result = 31 * result + (journalName != null ? journalName.hashCode() : 0);
-    result = 31 * result + (description != null ? description.hashCode() : 0);
-    result = 31 * result + (abstractText != null ? abstractText.hashCode() : 0);
-    result = 31 * result + (rights != null ? rights.hashCode() : 0);
-    result = 31 * result + (language != null ? language.hashCode() : 0);
-    result = 31 * result + (format != null ? format.hashCode() : 0);
-    result = 31 * result + (pageCount != null ? pageCount.hashCode() : 0);
-    result = 31 * result + (eLocationId != null ? eLocationId.hashCode() : 0);
-    result = 31 * result + (publicationDate != null ? publicationDate.hashCode() : 0);
-    result = 31 * result + (volume != null ? volume.hashCode() : 0);
-    result = 31 * result + (issue != null ? issue.hashCode() : 0);
-    result = 31 * result + (publisherLocation != null ? publisherLocation.hashCode() : 0);
-    result = 31 * result + (publisherName != null ? publisherName.hashCode() : 0);
-    result = 31 * result + (url != null ? url.hashCode() : 0);
-    result = 31 * result + (nlmArticleType != null ? nlmArticleType.hashCode() : 0);
-    result = 31 * result + (articleType != null ? articleType.hashCode() : 0);
-    result = 31 * result + (assets != null ? assets.hashCode() : 0);
-    result = 31 * result + (relatedArticles != null ? relatedArticles.hashCode() : 0);
-    result = 31 * result + (editors != null ? editors.hashCode() : 0);
-    return result;
+    public abstract Builder setDoi(String doi);
+    public abstract Builder setTitle(String title);
+    public abstract Builder setEissn(String eIssn);
+    public abstract Builder setJournalName(String journalName);
+    public abstract Builder setDescription(String description);
+    public abstract Builder setAbstractText(String abstractText);
+    public abstract Builder setRights(String rights);
+    public abstract Builder setLanguage(String language);
+    public abstract Builder setFormat(String format);
+    public abstract Builder setPageCount(Integer pageCount);
+    public abstract Builder seteLocationId(String eLocationId);
+    public abstract Builder setPublicationDate(LocalDate publicationDate);
+    public abstract Builder setVolume(String volume);
+    public abstract Builder setIssue(String issue);
+    public abstract Builder setPublisherLocation(String publisherLocation);
+    public abstract Builder setPublisherName(String publisherName);
+    public abstract Builder setUrl(String url);
+    public abstract Builder setNlmArticleType(String nlmArticleType);
+    public abstract Builder setArticleType(String articleType);
+    public abstract Builder setAssets(List<AssetMetadata> assets);
+    public abstract Builder setRelatedArticles(List<RelatedArticleLink> relatedArticles);
+    public abstract Builder setEditors(List<NlmPerson> editors);
   }
 }


### PR DESCRIPTION
This reintroduces the use of AutoValue.  We need to see how it is causing articles to fail to render in Wombat. I've been unable to reproduce locally.