### PR TITLE
Use default $HOME/ambra/config for rhino.configDir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <build.counter>0</build.counter>
+    <rhino.configDir>${env.HOME}/ambra/config</rhino.configDir>
   </properties>
 
   <repositories>
@@ -503,6 +504,7 @@
           <contextFile>${rhino.configDir}/context.xml</contextFile>
           <additionalConfigFilesDir>${rhino.configDir}/</additionalConfigFilesDir>
           <systemProperties>
+            <rhino.configDir>${rhino.configDir}</rhino.configDir><!-- this is necessary -->
             <java.util.logging.manager>org.apache.juli.ClassLoaderLogManager</java.util.logging.manager>
             <log4j.configuration>file://${rhino.configDir}/log4j.xml</log4j.configuration>
             <org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH>true


### PR DESCRIPTION
~/ambra/config is the directory suggested in the open source readme. Why not make it the default for the user running `mvn tomcat6:run` ?