### PR TITLE
AMBR-3 debian: install contentrepo in v2 context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -608,7 +608,7 @@
                 <data>
                   <src>${project.build.directory}/${project.build.finalName}.war</src>
                   <type>file</type>
-                  <dst>/opt/plos/rhino/webapps/rhino.war</dst>
+                  <dst>/opt/plos/rhino/webapps/v2.war</dst>
                 </data>
 
                 <data>


### PR DESCRIPTION
By installing in `rhino.war`, a user will need to visit: `http://hostname:PORT/rhino/` to see rhino.

Our salt scripts all rename `rhino.war` to `v2.war` to listen at `http://hostname:PORT/v2/`

This is overly complicated, in my opinion. Why not simply put it in `v2.war` in the debian package and skip the salt step?

Advantages:
- Installing the debian package works properly, and we do not need to run salt afterwards to get the proper setup
- Reduces the amount of salt code
- The only point of using a `/v2/` prefix is if it is always used, so that users can know what version of the API they are connecting to. If it is not always used it kind of seems pointless.

This should be safely mergeable without any change to salt, because the salt file move will noop if not necessary, and we can remove the salt code later.