### PR TITLE
AMBR-3 debian: do not db_purge in postinst

### DIFF
--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -59,9 +59,6 @@ case "$1" in
 
 ########### END app-specific code ###########
 
-	echo "Running db_purge"
-	db_purge
-
 	process_env_template $HOME/conf/context.template.xml $HOME/conf/context.xml
 
 	process_env_template $HOME/conf/server.template.xml $HOME/conf/server.xml


### PR DESCRIPTION
debian packages should not clear the questions answered when installing. This
should happen when the package is purged.

@jonocodes I suspect this was to hide passwords when they were stored as strings. Otherwise I'm not sure what this was for.