### PR TITLE
Put built .deb package into `/var/tmp/apt`, an apt repository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -653,8 +653,23 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <artifactId>apt-repo</artifactId>
+        <groupId>org.m1theo</groupId>
+        <version>0.3.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>apt-repo</goal>
+            </goals>
+            <configuration>
+              <repoDir>/var/tmp/apt</repoDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
-
   </build>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <ehcache.version>2.7.0</ehcache.version>
     <testng.version>6.9.10</testng.version>
     <google.truth.version>0.39</google.truth.version>
-    <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <build.counter>0</build.counter>
   </properties>


### PR DESCRIPTION
This changes the `mvn package` step to install the built `.deb` package into an apt repo located at `/tmp/apt`.

To be used in conjunction with https://github.com/PLOS/valdo/pull/58 https://github.com/PLOS/rhino/pull/422. This simplifies the process of testing `.deb` packages in a local vagrant environment.

With this 3 PRs merged, the process to install a new, locally built rhino `.deb` package is as follows:

From the host OS:

```
~/rhino/@host$ mvn package
...
[INFO] --- apt-repo:0.2.1:apt-repo (default) @ rhino ---
[INFO] repo dir: /tmp/apt
[INFO] found deb: rhino_2.4.4+20180226223703-plos0.deb
[INFO] Attaching file: /tmp/apt/rhino_2.4.4+20180226223703-plos0.deb
[INFO] Attaching created apt-repo files: /tmp/apt/Release, /tmp/apt/Packages.gz
...
```

Then, inside the guest:
```
# sudo apt-get update && apt-get upgrade -y
...
Preconfiguring packages ...
(Reading database ... 104059 files and directories currently installed.)
Preparing to unpack .../rhino_2.4.4+20180226223703-plos0.deb ...
 * Stopping Tomcat rhino servlet engine rhino                                                                                                           [ OK ] 
Unpacking rhino (2.4.4+20180226223703-plos0) over (2.4.4+20180223184220-plos0) ...
Processing triggers for ureadahead (0.100.0-16) ...
Setting up rhino (2.4.4+20180226223703-plos0) ...
Fetching configuration from debconf
Running db_purge
-rw-r--r-- 1 rhino rhino 1.5K Feb 26 14:37 /opt/plos/rhino/conf/context.template.xml
Processing template /opt/plos/rhino/conf/context.template.xml
-rw-r--r-- 1 rhino rhino 6.8K Feb 26 14:37 /opt/plos/rhino/conf/server.template.xml
Processing template /opt/plos/rhino/conf/server.template.xml
-rw-r--r-- 1 rhino rhino 1.6K Feb 26 14:37 /opt/plos/rhino/conf/tomcat-users.template.xml
Processing template /opt/plos/rhino/conf/tomcat-users.template.xml
-rwxr-xr-x 1 rhino rhino 64 Feb 26 14:37 /opt/plos/rhino/bin/setenv.template.sh
Processing template /opt/plos/rhino/bin/setenv.template.sh
 * Stopping Tomcat rhino servlet engine rhino                                                                                                           [ OK ] 
```

Super simple! No `dpkg -i ...` required, no manual copying of files between host and guest OS.

Note that this also increases the timestamp level of the .deb package version. This is to ensure that local builds always supersede others.

Without this, debian would prefer the build from the plos dev apt repo over the local build if they were build on the same day. This is because `rhino_2.4.4+20180226-plos1234.deb` is considered newer than `rhino_2.4.4+20180226-plos0.deb` (local builds have a build number of `0` always).