### PR TITLE
preserve private field name eIssn, not eissn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,7 @@
       <artifactId>swagger-springmvc</artifactId>
       <version>0.8.8</version>
     </dependency>
+
     <dependency>
     	<groupId>com.google.auto.value</groupId>
     	<artifactId>auto-value</artifactId>

--- a/src/main/java/org/ambraproject/rhino/content/xml/ArticleXml.java
+++ b/src/main/java/org/ambraproject/rhino/content/xml/ArticleXml.java
@@ -178,7 +178,7 @@ public class ArticleXml extends AbstractArticleXml<ArticleMetadata> {
       if (Strings.isNullOrEmpty(eissn)) {
         eissn = readString("/article/front/journal-meta/issn");
       }
-      article.setEissn(eissn);
+      article.seteIssn(eissn);
     }
     article.setJournalName(readString("/article/front/journal-meta/journal-title-group/journal-title"));
     article.setDescription(getXmlFromNode(findAbstractNode()));

--- a/src/main/java/org/ambraproject/rhino/model/article/ArticleMetadata.java
+++ b/src/main/java/org/ambraproject/rhino/model/article/ArticleMetadata.java
@@ -35,7 +35,7 @@ public abstract class ArticleMetadata {
   @Nullable public abstract String getDoi();
 
   @Nullable public abstract String getTitle();
-  @Nullable public abstract String getEissn();
+  @Nullable public abstract String geteIssn();
   @Nullable public abstract String getJournalName();
   @Nullable public abstract String getDescription();
   @Nullable public abstract String getAbstractText();
@@ -71,7 +71,7 @@ public abstract class ArticleMetadata {
 
     public abstract Builder setDoi(String doi);
     public abstract Builder setTitle(String title);
-    public abstract Builder setEissn(String eIssn);
+    public abstract Builder seteIssn(String eIssn);
     public abstract Builder setJournalName(String journalName);
     public abstract Builder setDescription(String description);
     public abstract Builder setAbstractText(String abstractText);

--- a/src/main/java/org/ambraproject/rhino/service/impl/HibernatePersistenceServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/HibernatePersistenceServiceImpl.java
@@ -155,7 +155,7 @@ public class HibernatePersistenceServiceImpl implements HibernatePersistenceServ
 
   private Journal fetchJournal(IngestPackage ingestPackage) {
     final ArticleMetadata articleMetadata = ingestPackage.getArticleMetadata();
-    final String eissn = articleMetadata.getEissn();
+    final String eissn = articleMetadata.geteIssn();
     final String bucketName = ingestPackage.getArticlePackage().getBucketName();
 
     Optional<Journal> journal;

--- a/src/test/java/org/ambraproject/rhino/model/article/ArticleMetadataTest.java
+++ b/src/test/java/org/ambraproject/rhino/model/article/ArticleMetadataTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Public Library of Science
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package org.ambraproject.rhino.model.article;
+
+import com.google.gson.Gson;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class ArticleMetadataTest {
+
+  @Test
+  public void testSerialization() throws Exception{
+    //confirm that eIssn is not serialized to lowercase eissn
+    ArticleMetadata am = ArticleMetadata.builder().seteIssn("12345").build();
+    String amJson = new Gson().toJson(am);
+    assertEquals(amJson, "{\"eIssn\":\"12345\"}");
+  }
+}

--- a/src/test/java/org/ambraproject/rhino/service/IngestionTest.java
+++ b/src/test/java/org/ambraproject/rhino/service/IngestionTest.java
@@ -444,7 +444,7 @@ public class IngestionTest extends BaseRhinoTest {
   private void compareArticleFields(AssertionCollector results, ArticleMetadata actual, ArticleMetadata expected) {
     compare(results, Article.class, "doi", actual.getDoi(), expected.getDoi());
     compareMarkupText(results, Article.class, "title", actual.getTitle(), expected.getTitle());
-    compare(results, Article.class, "eIssn", actual.getEissn(), expected.getEissn());
+    compare(results, Article.class, "eIssn", actual.geteIssn(), expected.geteIssn());
     compareMarkupText(results, Article.class, "description", actual.getDescription(), expected.getDescription());
     compareRights(results, actual.getRights(), expected.getRights());
     compare(results, Article.class, "language", actual.getLanguage(), expected.getLanguage());

--- a/src/test/java/org/ambraproject/rhino/service/impl/HibernatePersistenceServiceTest.java
+++ b/src/test/java/org/ambraproject/rhino/service/impl/HibernatePersistenceServiceTest.java
@@ -158,7 +158,7 @@ public class HibernatePersistenceServiceTest extends AbstractRhinoTest {
 
     expectedArticleMetadata = ArticleMetadata.builder().setTitle("Meta title")
         .setArticleType("MetaArticleType")
-        .setEissn(EISSN)
+        .seteIssn(EISSN)
         .setJournalName(META_JOURNAL_NAME)
         .setPublicationDate(publishedOn).build();
 


### PR DESCRIPTION
Corrects the capitalization of the generated field name back to 'eIssn'.  This was accidentally changed to 'eissn' when I added AutoValue.