### PR TITLE
First pass at working Rhino for TPR

### DIFF
--- a/src/main/java/org/ambraproject/rhino/content/xml/AbstractArticleXml.java
+++ b/src/main/java/org/ambraproject/rhino/content/xml/AbstractArticleXml.java
@@ -70,10 +70,11 @@ public abstract class AbstractArticleXml<T> extends AbstractXpathReader {
   protected static final String TABLE_WRAP = "table-wrap";
   protected static final String ALTERNATIVES = "alternatives";
   protected static final String DISP_FORMULA = "disp-formula";
+  protected static final String DECISION_LETTER = "response";
 
   // The node-names for nodes that can be an asset on their own
   protected static final ImmutableSet<String> ASSET_NODE_NAMES = ImmutableSet.of(
-      "supplementary-material", "inline-formula", DISP_FORMULA, GRAPHIC);
+      "supplementary-material", "inline-formula", DISP_FORMULA, GRAPHIC,DECISION_LETTER);
 
   // The node-names for nodes that can be an asset if they have a descendant <graphic> node
   protected static final ImmutableSet<String> GRAPHIC_NODE_PARENTS = ImmutableSet.of(TABLE_WRAP, "fig",
@@ -92,6 +93,8 @@ public abstract class AbstractArticleXml<T> extends AbstractXpathReader {
         //disp-formula may be a graphic node parent, or an asset node name
         doi = readHrefAttribute(assetNode);
       }
+    } else if (DECISION_LETTER.equalsIgnoreCase(nodeName)) {
+      doi = readString("front-stub/article-id[@pub-id-type=\"doi\"]", assetNode);
     } else if (ASSET_NODE_NAMES.contains(nodeName)) {
       doi = readHrefAttribute(assetNode);
     } else {

--- a/src/main/java/org/ambraproject/rhino/content/xml/AssetXml.java
+++ b/src/main/java/org/ambraproject/rhino/content/xml/AssetXml.java
@@ -55,10 +55,17 @@ public class AssetXml extends AbstractArticleXml<AssetMetadata> {
   @Override
   public AssetMetadata build() throws XmlContentException {
     String doi = assetId.getName();
+    String title = "";
+    String description = "";
 
-    String title = Strings.nullToEmpty(readString("child::label"));
-    Node captionNode = readNode("child::caption");
-    String description = Strings.nullToEmpty(getXmlFromNode(captionNode));
+    if (xml.getLocalName().equalsIgnoreCase(DECISION_LETTER)) {
+      title = Strings.nullToEmpty(readString("front-stub/title-group/article-title"));
+      description = Strings.nullToEmpty(readString("@response-type"));
+    } else {
+      title = Strings.nullToEmpty(readString("child::label"));
+      Node captionNode = readNode("child::caption");
+      description = Strings.nullToEmpty(getXmlFromNode(captionNode));
+    }
 
     return new AssetMetadata(doi, title, description);
   }

--- a/src/main/java/org/ambraproject/rhino/model/ingest/ArticlePackageBuilder.java
+++ b/src/main/java/org/ambraproject/rhino/model/ingest/ArticlePackageBuilder.java
@@ -203,6 +203,8 @@ public class ArticlePackageBuilder {
         return AssetType.GRAPHIC;
       case "supplementary-material":
         return AssetType.SUPPLEMENTARY_MATERIAL;
+      case "response":
+        return AssetType.REVIEW_LETTER;
       default:
         throw new RestClientException("XML node name could not be matched to asset type: " + nodeName, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/org/ambraproject/rhino/model/ingest/AssetType.java
+++ b/src/main/java/org/ambraproject/rhino/model/ingest/AssetType.java
@@ -78,6 +78,15 @@ public enum AssetType {
     }
   },
 
+  REVIEW_LETTER {
+    private final ImmutableSet<FileType> TYPES = Sets.immutableEnumSet(FileType.LETTER);
+
+    @Override
+    protected ImmutableSet<FileType> getSupportedFileTypes() {
+      return TYPES;
+    }
+  },
+
   SUPPLEMENTARY_MATERIAL {
     private final ImmutableSet<FileType> TYPES = Sets.immutableEnumSet(FileType.SUPPLEMENTARY);
 

--- a/src/main/java/org/ambraproject/rhino/model/ingest/FileType.java
+++ b/src/main/java/org/ambraproject/rhino/model/ingest/FileType.java
@@ -48,6 +48,9 @@ public enum FileType {
   // Display formats at different sizes for figures and tables
   SMALL, MEDIUM, INLINE, LARGE,
 
+  // TPR Letter Type
+  LETTER,
+
   // A supplementary information file, which should always be the only file with its DOI
   SUPPLEMENTARY;
 


### PR DESCRIPTION
#AMBR-606 - Added a "reviewLetter" type to Rhino ingester. This allows the creation of virtual TPR asset (<Response> blocks). Should not alter functionality is long as TPR data does not exist in the manifest.