### PR TITLE
Use 8082 as port when started by mvn tomcat plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <build.counter>0</build.counter>
+    <maven.tomcat.port>8082</maven.tomcat.port>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Sets a default port (8082) when starting rhino using `mvn tomcat6:run`