### PR TITLE
Use 8007 as default shutdown port

### DIFF
--- a/src/deb/control/templates
+++ b/src/deb/control/templates
@@ -35,5 +35,5 @@ Description: The HTTP port you would like Rhino to be accessible from
 
 Template: [[artifactId]]/control_port
 Type: string
-Default: 8005
+Default: 8007
 Description: The TCP port to use for Tomcat shutdown control port


### PR DESCRIPTION
8005 is used as the shutdown port by contentrepo. This is overwritten in salt, but we may as well change the default to not conflict with contentrepo.