### PR TITLE
Use random JMX ports

### DIFF
--- a/src/deb/tomcat7/conf/server.template.xml
+++ b/src/deb/tomcat7/conf/server.template.xml
@@ -36,7 +36,7 @@
 
     <!-- JMX Support for the Tomcat server.-->
     <Listener className="org.apache.catalina.mbeans.JmxRemoteLifecycleListener"
-              rmiRegistryPortPlatform="21212" rmiServerPortPlatform="21213"
+              rmiRegistryPortPlatform="0" rmiServerPortPlatform="0"
               useLocalPorts="true" />
 
     <!-- Global JNDI resources


### PR DESCRIPTION
Rather than use preset JMX ports, use `0`, which chooses an open port at random, to avoid conflicts.

@wryfi @heschlie I'm not sure if this will work with prometheus.