### PR TITLE
Add a simple landing page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -648,6 +648,15 @@
                   </mapper>
                 </data>
 
+                <data>
+                  <src>${project.basedir}/root-index.html</src>
+                  <type>file</type>
+                  <dst>/opt/plos/rhino/webapps/ROOT/index.html</dst>
+                  <mapper>
+                    <type>perm</type>
+                    <filemode>755</filemode>
+                  </mapper>
+                </data>
               </dataSet>
             </configuration>
           </execution>

--- a/root-index.html
+++ b/root-index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Welcome to rhino</title>
+  </head>
+  <body>
+    <p>Welcome to rhino. Click <a href='/v2/'>here</a> for docs.</p>
+  </body>
+</html>


### PR DESCRIPTION
It's disconcerting to visit a web service and not see anything.

Especially on recent versions of chrome where the 404 looks pretty close to the server not answering

![before-404](https://user-images.githubusercontent.com/22718/46237344-bbbb4f80-c338-11e8-8b46-cbd275caf69e.png)

This change add a simple landing page which links to the rhino API docs:

![200-after](https://user-images.githubusercontent.com/22718/46237598-549e9a80-c33a-11e8-88ea-2937e77e9629.png)


