### PR TITLE
Changes for response to sub-article redo.

### DIFF
--- a/src/main/java/org/ambraproject/rhino/content/xml/AbstractArticleXml.java
+++ b/src/main/java/org/ambraproject/rhino/content/xml/AbstractArticleXml.java
@@ -70,7 +70,7 @@ public abstract class AbstractArticleXml<T> extends AbstractXpathReader {
   protected static final String TABLE_WRAP = "table-wrap";
   protected static final String ALTERNATIVES = "alternatives";
   protected static final String DISP_FORMULA = "disp-formula";
-  protected static final String DECISION_LETTER = "response";
+  protected static final String DECISION_LETTER = "sub-article";
 
   // The node-names for nodes that can be an asset on their own
   protected static final ImmutableSet<String> ASSET_NODE_NAMES = ImmutableSet.of(

--- a/src/main/java/org/ambraproject/rhino/content/xml/AssetXml.java
+++ b/src/main/java/org/ambraproject/rhino/content/xml/AssetXml.java
@@ -60,7 +60,7 @@ public class AssetXml extends AbstractArticleXml<AssetMetadata> {
 
     if (xml.getLocalName().equalsIgnoreCase(DECISION_LETTER)) {
       title = Strings.nullToEmpty(readString("front-stub/title-group/article-title"));
-      description = Strings.nullToEmpty(readString("@response-type"));
+      description = Strings.nullToEmpty(readString("@article-type"));
     } else {
       title = Strings.nullToEmpty(readString("child::label"));
       Node captionNode = readNode("child::caption");

--- a/src/main/java/org/ambraproject/rhino/model/ingest/ArticlePackageBuilder.java
+++ b/src/main/java/org/ambraproject/rhino/model/ingest/ArticlePackageBuilder.java
@@ -203,7 +203,7 @@ public class ArticlePackageBuilder {
         return AssetType.GRAPHIC;
       case "supplementary-material":
         return AssetType.SUPPLEMENTARY_MATERIAL;
-      case "response":
+      case "sub-article":
         return AssetType.REVIEW_LETTER;
       default:
         throw new RestClientException("XML node name could not be matched to asset type: " + nodeName, HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
The working group has recommended that <sub-article> be used in place of <response> for TPR data in JATs. These changes simply support the use of  <sub-article>. No code changes but changes to a couple of strings.