### PR TITLE
Set project.build.sourceEncoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <build.counter>0</build.counter>
     <maven.tomcat.port>8082</maven.tomcat.port>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Eliminates the following warning:
```
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```

This should have no effect on the build itself, because it is using UTF-8 (see https://teamcity.plos.org/teamcity/viewLog.html?buildId=176454&buildTypeId=Diprotodon_RaroBuildJobs_RhinoTest&tab=buildLog&_focus=388#_state=336) but it will eliminate a warning message.