### PR TITLE
AMBR-1015 Fix paging

### DIFF
--- a/src/main/java/org/ambraproject/rhino/service/impl/ArticleCrudServiceImpl.java
+++ b/src/main/java/org/ambraproject/rhino/service/impl/ArticleCrudServiceImpl.java
@@ -668,6 +668,7 @@ public class ArticleCrudServiceImpl extends AmbraService implements ArticleCrudS
         } else {
           criteria.addOrder(Order.desc("created" /* propertyName */));
         }
+        criteria.addOrder(Order.asc("articleId"));
 
         @SuppressWarnings("unchecked")
         final List<String> articleDois = (List<String>) hibernateTemplate.findByCriteria(

--- a/src/main/resources/db/migration/V3__add_created_index_to_article.sql
+++ b/src/main/resources/db/migration/V3__add_created_index_to_article.sql
@@ -1,0 +1,1 @@
+CREATE INDEX article_created ON article (created);


### PR DESCRIPTION
https://jira.plos.org/jira/browse/AMBR-1015

I haven't been able to actually show this code changes fixes the problem, because I can't reproduce the problem locally. However, I can show that adding the additional sort fixes the underlying mysql pagination problem:

```
mysql> select doi from article order by created asc limit 10;
+----------------------------+
| doi                        |
+----------------------------+
| 10.1371/image.pbio.v02.i08 |
| 10.1371/image.pbio.v02.i07 |
| 10.1371/image.pbio.v02.i06 |
| 10.1371/image.pbio.v02.i05 |
| 10.1371/image.pbio.v02.i04 |
| 10.1371/image.pbio.v02.i03 |
| 10.1371/image.pbio.v02.i02 |
| 10.1371/image.pbio.v02.i01 |
| 10.1371/image.pbio.v01.i03 |
| 10.1371/image.pbio.v01.i02 |
+----------------------------+
10 rows in set (0.27 sec)

mysql> select doi from article order by created asc limit 5;
+----------------------------+
| doi                        |
+----------------------------+
| 10.1371/image.pbio.v01.i02 |
| 10.1371/image.pbio.v01.i03 |
| 10.1371/image.pbio.v02.i01 |
| 10.1371/image.pbio.v02.i02 |
| 10.1371/image.pbio.v02.i03 |
+----------------------------+
5 rows in set (0.30 sec)

mysql> select doi from article order by created asc limit 5,5;
+----------------------------+
| doi                        |
+----------------------------+
| 10.1371/image.pbio.v02.i03 |
| 10.1371/image.pbio.v02.i02 |
| 10.1371/image.pbio.v02.i01 |
| 10.1371/image.pbio.v01.i03 |
| 10.1371/image.pbio.v01.i02 |
+----------------------------+
5 rows in set (0.32 sec)
```

Notice that the 2 queries for 5 items each include repetitions and miss some entries. If we add an additional ordering, this is corrected:
```
mysql> select doi from article order by created asc, articleId asc limit 10;
+----------------------------+
| doi                        |
+----------------------------+
| 10.1371/image.pbio.v01.i01 |
| 10.1371/image.pbio.v01.i02 |
| 10.1371/image.pbio.v01.i03 |
| 10.1371/image.pbio.v02.i01 |
| 10.1371/image.pbio.v02.i02 |
| 10.1371/image.pbio.v02.i03 |
| 10.1371/image.pbio.v02.i04 |
| 10.1371/image.pbio.v02.i05 |
| 10.1371/image.pbio.v02.i06 |
| 10.1371/image.pbio.v02.i07 |
+----------------------------+
10 rows in set (0.39 sec)

mysql> select doi from article order by created asc, articleId asc limit 5;
+----------------------------+
| doi                        |
+----------------------------+
| 10.1371/image.pbio.v01.i01 |
| 10.1371/image.pbio.v01.i02 |
| 10.1371/image.pbio.v01.i03 |
| 10.1371/image.pbio.v02.i01 |
| 10.1371/image.pbio.v02.i02 |
+----------------------------+
5 rows in set (0.28 sec)

mysql> select doi from article order by created asc, articleId asc limit 5,5;
+----------------------------+
| doi                        |
+----------------------------+
| 10.1371/image.pbio.v02.i03 |
| 10.1371/image.pbio.v02.i04 |
| 10.1371/image.pbio.v02.i05 |
| 10.1371/image.pbio.v02.i06 |
| 10.1371/image.pbio.v02.i07 |
+----------------------------+
5 rows in set (0.30 sec)
```

This is because these rows have the same `created` timestamp and the order is undefined when the rows have the same timestamp. We need a total ordering of all the rows to make pagination work properly.