### PR TITLE
repo1.maven.org is no longer available via http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,21 +84,6 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>central</id>
-      <name>Maven Repository Switchboard</name>
-      <layout>default</layout>
-      <url>http://repo1.maven.org/maven2</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>JBoss</id>
-      <name>JBoss Repsitory</name>
-      <layout>default</layout>
-      <url>http://repository.jboss.org/maven2</url>
-    </repository>
   </repositories>
 
   <distributionManagement>


### PR DESCRIPTION
Solution is to stop specifying the central repo in pom.xml, there is no need.