### PR TITLE
add initial jib configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,23 @@
            </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>2.1.0</version>
+        <configuration>
+          <to>
+            <image>docker.io/plos/rhino:${project.version}</image>
+          </to>
+          <from>
+            <image>docker.io/plos/tomcat:latest</image>
+          </from>
+          <container>
+            <appRoot>/usr/local/tomcat/webapps/rhino</appRoot>
+          </container>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This uses Google's Jib plugin to publish a docker image of rhino. It's using a plos-specific tomcat base image with the correct JVM and mysq libraries installed. Build with jib:dockerBuild goal.