### PR TITLE
Fix URL generation problem in recent java versions

### DIFF
--- a/src/main/java/org/ambraproject/rhino/identity/Doi.java
+++ b/src/main/java/org/ambraproject/rhino/identity/Doi.java
@@ -69,28 +69,28 @@ public final class Doi {
     HTTPS_DOI_RESOLVER("https://doi.org/") {
       @Override
       protected URI convert(String doiName) throws URISyntaxException, MalformedURLException {
-        return new URL("https", "doi.org/", doiName).toURI();
+        return new URL("https", "doi.org", "/" + doiName).toURI();
       }
     },
 
     HTTP_DOI_RESOLVER("http://doi.org/") {
       @Override
       protected URI convert(String doiName) throws URISyntaxException, MalformedURLException {
-        return new URL("http", "doi.org/", doiName).toURI();
+        return new URL("http", "doi.org", "/" + doiName).toURI();
       }
     },
 
     HTTPS_DX_RESOLVER("https://dx.doi.org/") {
       @Override
       protected URI convert(String doiName) throws URISyntaxException, MalformedURLException {
-        return new URL("https", "dx.doi.org/", doiName).toURI();
+        return new URL("https", "dx.doi.org", "/" + doiName).toURI();
       }
     },
 
     HTTP_DX_RESOLVER("http://dx.doi.org/") {
       @Override
       protected URI convert(String doiName) throws URISyntaxException, MalformedURLException {
-        return new URL("http", "dx.doi.org/", doiName).toURI();
+        return new URL("http", "dx.doi.org", "/" + doiName).toURI();
       }
     };
 


### PR DESCRIPTION
Small fix that I back-ported from the GCS branch.

Previous to this fix, recent versions of java would error with:

Tests in error:
  testDoi[2: 10.1371/foo, INFO_DOI, HTTPS_DOI_RESOLVER](org.ambraproject.rhino.identity.DoiTest): java.net.MalformedURLException: Illegal character found in host: '/'