### PR TITLE
Bump mysql-connector version (used by cargo)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.12</version>
+      <version>5.1.49</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Allows connecting to more recent versions of mysql server.