### PR TITLE
Bump swagger springmvc to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,14 @@
     <dependency>
       <groupId>com.mangofactory</groupId>
       <artifactId>swagger-springmvc</artifactId>
-      <version>0.8.8</version>
+      <version>1.0.2</version>
+    </dependency>
+
+    <!-- for use by swagger-springmvc, which for some reason does not require it directly -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.11.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/ambraproject/rhino/config/SwaggerConfiguration.java
+++ b/src/main/java/org/ambraproject/rhino/config/SwaggerConfiguration.java
@@ -23,9 +23,9 @@
 package org.ambraproject.rhino.config;
 
 import com.mangofactory.swagger.configuration.SpringSwaggerConfig;
+import com.mangofactory.swagger.models.dto.ApiInfo;
 import com.mangofactory.swagger.plugin.EnableSwagger;
 import com.mangofactory.swagger.plugin.SwaggerSpringMvcPlugin;
-import com.wordnik.swagger.model.ApiInfo;
 import org.ambraproject.rhino.service.ConfigurationReadService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
In addition to being a more recent version (always good) this reduces
the number of jars included; scala is no longer necessary.