### PR TITLE
ENG-325 cargo requires https mvn repo url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
           <container>
             <containerId>tomcat8x</containerId>
             <zipUrlInstaller>
-              <url>http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/8.0.32/tomcat-8.0.32.zip</url>
+              <url>https://repo1.maven.org/maven2/org/apache/tomcat/tomcat/8.0.32/tomcat-8.0.32.zip</url>
             </zipUrlInstaller>
             <systemProperties>
               <java.util.logging.manager>org.apache.juli.ClassLoaderLogManager</java.util.logging.manager>


### PR DESCRIPTION
`mvn cargo:run` failed getting tomcat via HTTP

```
501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
```