### PR TITLE
ENG-325 sort issues by doi

### DIFF
--- a/src/main/java/org/ambraproject/rhino/model/Volume.java
+++ b/src/main/java/org/ambraproject/rhino/model/Volume.java
@@ -34,7 +34,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
-import javax.persistence.OrderColumn;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import java.util.Date;
@@ -73,7 +73,7 @@ public class Volume implements Timestamped {
   @Cascade(CascadeType.SAVE_UPDATE)
   @OneToMany(fetch = FetchType.EAGER)
   @JoinColumn(name = "volumeId", nullable = false)
-  @OrderColumn(name="volumeSortOrder")
+  @OrderBy("doi")
   private List<Issue> issues;
 
   public Volume() {

--- a/src/main/resources/db/migration/V6__remove_volume_sort_order_from_issue.sql
+++ b/src/main/resources/db/migration/V6__remove_volume_sort_order_from_issue.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `issue` DROP COLUMN `volumeSortOrder`;


### PR DESCRIPTION
https://jira.plos.org/jira/browse/ENG-325

Dev journals is set up with the February issue of NTDs Vol. 10 sorted at the end, as you can see here:
http://journals-dev1-backend1.soma.plos.org:8006/v2/journals/PLoSNTD/volumes/10.1371%2B%2Bvolume.pntd.v10/issues

To test:
- configure to point to dev backend db
- run `mvn clean package cargo:run -DconfigDir=/etc/ambra`
- view issues sorted correctly here: http://localhost:8082/v2/journals/PLoSNTD/volumes/10.1371%2B%2Bvolume.pntd.v10/issues